### PR TITLE
Skip reward.json on infrastructure failures

### DIFF
--- a/src/gandalf_grader/__main__.py
+++ b/src/gandalf_grader/__main__.py
@@ -407,13 +407,32 @@ def _run_batch(
     return results, llm_usage
 
 
+def _is_infra_failure(results: list[CriteriaResult]) -> bool:
+    """Return True if no criterion was actually evaluated by the judge.
+
+    When every criterion failed without producing any evidence, the failures
+    are almost certainly caused by infrastructure problems (LLM API down,
+    missing API keys, workspace clone errors, etc.) rather than the agent
+    genuinely failing every check.
+    """
+    return bool(results) and not any(r.passed or r.evidence for r in results)
+
+
 def _compute_and_write_results(
     config: VerifierConfig,
     rubric: list[RubricItem],
     results: list[CriteriaResult],
     llm_usage: dict[str, Any],
+    *,
+    write_reward: bool = True,
 ) -> None:
-    """Compute the weighted score and write reward.json / info.json."""
+    """Compute the weighted score and write reward.json / info.json.
+
+    When *write_reward* is False, only ``info.json`` is written (for
+    debugging) and ``reward.json`` is deliberately omitted so the caller
+    (e.g. Harbor) can detect the missing file and treat the trial as an
+    infrastructure error rather than a legitimate score of 0.0.
+    """
     total_weight = sum(r.weight for r in results)
     score = round(
         sum(r.weight * (1.0 if r.passed else 0.0) for r in results) / total_weight if total_weight > 0 else 0.0,
@@ -425,8 +444,9 @@ def _compute_and_write_results(
     total_completion = llm_usage.get("completion_tokens", 0)
     total_cache_read = llm_usage.get("cache_read_tokens", 0)
 
-    with open(os.path.join(config.output_dir, "reward.json"), "w") as f:
-        json.dump({"score": score}, f, indent=2)
+    if write_reward:
+        with open(os.path.join(config.output_dir, "reward.json"), "w") as f:
+            json.dump({"score": score}, f, indent=2)
 
     info = EvaluationInfo(
         score=score,
@@ -488,17 +508,22 @@ def main() -> None:
     else:
         results, llm_usage = _run_sequential(config, rubric, final_output, judge_guidance)
 
-    _compute_and_write_results(config, rubric, results, llm_usage)
+    infra_failure = _is_infra_failure(results)
 
-    # If no criterion was actually evaluated by the judge (all failed due to
-    # infrastructure issues like sudo, missing API keys, workspace clone errors),
-    # exit non-zero so the caller can distinguish infrastructure errors from
-    # a legitimate score of 0.0.
-    evaluated = any(r.passed or r.evidence for r in results)
-    if results and not evaluated:
+    # Write info.json always (for debugging), but skip reward.json when every
+    # criterion failed without evidence — that indicates infrastructure errors,
+    # not a genuine evaluation.  By omitting reward.json the caller (e.g.
+    # Harbor) will raise RewardFileNotFoundError and count the trial as an
+    # error instead of silently recording score=0.0.
+    _compute_and_write_results(
+        config, rubric, results, llm_usage, write_reward=not infra_failure,
+    )
+
+    if infra_failure:
         print(
             "\nERROR: No criteria were successfully evaluated. "
-            "All failures appear to be infrastructure errors.",
+            "All failures appear to be infrastructure errors.\n"
+            "reward.json was NOT written — the caller should treat this as an error.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -6,8 +6,15 @@ from unittest.mock import patch
 
 import pytest
 
-from gandalf_grader.__main__ import _JUDGE_ENV_ALLOWLIST, _judge_env_vars, evaluate_all_criteria, resolve_judge_guidance
-from gandalf_grader.config import BatchJudgeInput, VerifierConfig
+from gandalf_grader.__main__ import (
+    _JUDGE_ENV_ALLOWLIST,
+    _compute_and_write_results,
+    _is_infra_failure,
+    _judge_env_vars,
+    evaluate_all_criteria,
+    resolve_judge_guidance,
+)
+from gandalf_grader.config import BatchJudgeInput, CriteriaResult, RubricItem, VerifierConfig
 
 
 def _make_config(**overrides) -> VerifierConfig:
@@ -369,3 +376,101 @@ class TestEvaluateAllCriteria:
         assert len(verdicts) == 2
         assert all(v["passed"] is False for v in verdicts)
         assert usage == {}
+
+
+class TestIsInfraFailure:
+    """Tests for _is_infra_failure detection."""
+
+    def test_all_failed_no_evidence_is_infra(self):
+        results = [
+            CriteriaResult(criteria="c1", weight=1, passed=False, reasoning="Judge error", evidence=[]),
+            CriteriaResult(criteria="c2", weight=1, passed=False, reasoning="Judge error", evidence=[]),
+        ]
+        assert _is_infra_failure(results) is True
+
+    def test_one_passed_is_not_infra(self):
+        results = [
+            CriteriaResult(criteria="c1", weight=1, passed=True, reasoning="ok", evidence=[]),
+            CriteriaResult(criteria="c2", weight=1, passed=False, reasoning="no", evidence=[]),
+        ]
+        assert _is_infra_failure(results) is False
+
+    def test_failed_with_evidence_is_not_infra(self):
+        results = [
+            CriteriaResult(
+                criteria="c1", weight=1, passed=False, reasoning="no",
+                evidence=["Read file: contents were wrong"],
+            ),
+        ]
+        assert _is_infra_failure(results) is False
+
+    def test_empty_results_is_not_infra(self):
+        assert _is_infra_failure([]) is False
+
+    def test_mixed_evidence_is_not_infra(self):
+        results = [
+            CriteriaResult(criteria="c1", weight=1, passed=False, reasoning="error", evidence=[]),
+            CriteriaResult(
+                criteria="c2", weight=1, passed=False, reasoning="checked",
+                evidence=["Ran command: no output"],
+            ),
+        ]
+        assert _is_infra_failure(results) is False
+
+
+class TestComputeAndWriteResults:
+    """Tests for _compute_and_write_results reward.json / info.json output."""
+
+    def _make_results(self, passed_flags):
+        return [
+            CriteriaResult(
+                criteria=f"criterion {i}",
+                weight=1.0,
+                passed=p,
+                reasoning="ok" if p else "fail",
+                evidence=["checked"] if p else [],
+            )
+            for i, p in enumerate(passed_flags)
+        ]
+
+    def _make_rubric(self, n):
+        return [RubricItem(criteria=f"criterion {i}", weight=1.0) for i in range(n)]
+
+    def test_writes_both_files_by_default(self, tmp_path):
+        config = _make_config(output_dir=str(tmp_path))
+        results = self._make_results([True, False])
+        rubric = self._make_rubric(2)
+
+        _compute_and_write_results(config, rubric, results, {})
+
+        assert (tmp_path / "reward.json").exists()
+        assert (tmp_path / "info.json").exists()
+        reward = json.loads((tmp_path / "reward.json").read_text())
+        assert reward["score"] == 0.5
+
+    def test_skips_reward_when_write_reward_false(self, tmp_path):
+        config = _make_config(output_dir=str(tmp_path))
+        results = self._make_results([False, False])
+        rubric = self._make_rubric(2)
+
+        _compute_and_write_results(config, rubric, results, {}, write_reward=False)
+
+        assert not (tmp_path / "reward.json").exists()
+        assert (tmp_path / "info.json").exists()
+
+    def test_info_json_written_even_on_infra_failure(self, tmp_path):
+        config = _make_config(output_dir=str(tmp_path))
+        results = [
+            CriteriaResult(
+                criteria="c1", weight=1.0, passed=False,
+                reasoning="Judge execution error: API down", evidence=[],
+            ),
+        ]
+        rubric = self._make_rubric(1)
+
+        _compute_and_write_results(config, rubric, results, {}, write_reward=False)
+
+        assert not (tmp_path / "reward.json").exists()
+        info = json.loads((tmp_path / "info.json").read_text())
+        assert info["score"] == 0.0
+        assert "API down" in info["criteria_results"][0]["reasoning"]


### PR DESCRIPTION
## Summary

When all rubric criteria fail without producing any evidence (e.g. the LLM API is unreachable, API keys are missing, or workspace cloning fails), gandalf-grader was writing `reward.json` with `score: 0.0` **before** calling `sys.exit(1)`. This caused a silent failure:

1. The inner judge catches the LLM connection error and converts it to failed verdicts (exits 0)
2. The outer orchestrator reads those verdicts, writes `reward.json` with `{"score": 0.0}`, then detects the infra failure and calls `sys.exit(1)`
3. **Harbor ignores the exit code** — its `exec()` method runs with `check=False` — and finds the `reward.json` file already on disk
4. Harbor parses `{"score": 0.0}` as a legitimate result → `n_errors: 0`, making the infrastructure outage indistinguishable from a genuine agent failure

### The fix

- Extract the existing infrastructure-failure detection into `_is_infra_failure()` and move it **before** the file-write step
- Add a `write_reward` parameter to `_compute_and_write_results()` — when False, only `info.json` is written (for debugging), and `reward.json` is deliberately omitted
- The missing `reward.json` causes Harbor to raise `RewardFileNotFoundError`, correctly counting the trial as an error and making it eligible for retry

### What doesn't change

- `info.json` is always written (contains per-criteria error messages for debugging)
- `sys.exit(1)` still fires on infrastructure failures
- Normal evaluation (any criterion has evidence or passes) is completely unaffected
- The `write_reward=True` default preserves backward compatibility

## Test plan

- [x] `TestIsInfraFailure` — 5 tests covering all edge cases (all-fail-no-evidence, one-pass, fail-with-evidence, empty results, mixed)
- [x] `TestComputeAndWriteResults` — 3 tests verifying reward.json is written/skipped correctly and info.json is always present
- [x] Full suite: 89 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)