### PR TITLE
Fix: tolerate extra fields in LLM tool-call arguments

### DIFF
--- a/src/gandalf_grader/judge.py
+++ b/src/gandalf_grader/judge.py
@@ -276,6 +276,36 @@ def _make_verdict_path(prefix: str = "verdict_") -> str:
     )
 
 
+def _patch_action_schemas_to_ignore_extra() -> None:
+    """Relax Pydantic ``extra="forbid"`` on OpenHands tool action schemas.
+
+    LLMs occasionally include unexpected keys in tool-call arguments (e.g.
+    ``evidence`` from the verdict schema leaking into a ``terminal`` call).
+    The upstream ``Action`` base sets ``extra="forbid"`` which causes a hard
+    ``ValidationError`` for any extra key.  Changing it to ``"ignore"``
+    silently drops the spurious keys and lets the tool call proceed.
+
+    This is a targeted monkey-patch applied to the ``Action`` base class
+    and the two concrete subclasses used by the judge agent.
+    """
+    from openhands.sdk.tool.schema import Action
+    from openhands.tools.file_editor import FileEditorAction
+    from openhands.tools.terminal import TerminalAction
+    from pydantic import ConfigDict
+
+    if Action.model_config.get("extra") == "ignore":
+        return  # already patched
+
+    # Pydantic bakes the config into a compiled validator at class-creation
+    # time.  We must update model_config on every class in the hierarchy
+    # and force a full rebuild so the validator is re-compiled.
+    for cls in (Action, TerminalAction, FileEditorAction):
+        cls.model_config = ConfigDict(
+            **{**cls.model_config, "extra": "ignore"},
+        )
+        cls.model_rebuild(force=True)
+
+
 def _run_agent_session(
     model: str,
     mcp_servers: list[dict[str, Any]],
@@ -290,6 +320,8 @@ def _run_agent_session(
     from openhands.sdk import LLM, Agent, Conversation, Tool
     from openhands.tools.file_editor import FileEditorTool
     from openhands.tools.terminal import TerminalTool
+
+    _patch_action_schemas_to_ignore_extra()
 
     api_key = os.environ.get("LLM_API_KEY")
     if not api_key:

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1,6 +1,8 @@
 """Tests for gandalf_grader.judge."""
 
 import json
+import sys
+import types
 from unittest.mock import patch
 
 from gandalf_grader.judge import (
@@ -458,3 +460,91 @@ class TestRunJudgeBatch:
         assert data["llm_usage"]["prompt_tokens"] == 1000
         assert all(v["passed"] is False for v in data["verdicts"])
         assert "Batch parsing blew up" in data["verdicts"][0]["reasoning"]
+
+
+class TestPatchActionSchemas:
+    """Tests for _patch_action_schemas_to_ignore_extra.
+
+    Uses lightweight Pydantic stand-ins so the test runs without openhands installed.
+    Each test creates *fresh* classes to avoid cross-test pollution.
+    """
+
+    def _install_fake_openhands(self):
+        """Install minimal fake openhands modules that mirror the real hierarchy.
+
+        Returns fresh classes each time so tests are fully independent.
+        """
+        from pydantic import BaseModel
+        from pydantic import ConfigDict as CD
+
+        class FakeAction(BaseModel):
+            model_config = CD(extra="forbid", frozen=True)
+
+        class FakeTerminalAction(FakeAction):
+            command: str = ""
+
+        class FakeFileEditorAction(FakeAction):
+            command: str = ""
+            path: str = ""
+
+        # Build a module tree that matches the imports in the patch function.
+        schema_mod = types.ModuleType("openhands.sdk.tool.schema")
+        schema_mod.Action = FakeAction  # type: ignore[attr-defined]
+
+        terminal_mod = types.ModuleType("openhands.tools.terminal")
+        terminal_mod.TerminalAction = FakeTerminalAction  # type: ignore[attr-defined]
+
+        file_editor_mod = types.ModuleType("openhands.tools.file_editor")
+        file_editor_mod.FileEditorAction = FakeFileEditorAction  # type: ignore[attr-defined]
+
+        # Register parent packages so Python's import machinery is happy.
+        for name in (
+            "openhands",
+            "openhands.sdk",
+            "openhands.sdk.tool",
+            "openhands.sdk.tool.schema",
+            "openhands.tools",
+            "openhands.tools.terminal",
+            "openhands.tools.file_editor",
+        ):
+            sys.modules.setdefault(name, types.ModuleType(name))
+
+        sys.modules["openhands.sdk.tool.schema"] = schema_mod
+        sys.modules["openhands.tools.terminal"] = terminal_mod
+        sys.modules["openhands.tools.file_editor"] = file_editor_mod
+
+        return FakeAction, FakeTerminalAction, FakeFileEditorAction
+
+    def test_patch_changes_extra_to_ignore(self):
+        Action, TerminalAction, FileEditorAction = self._install_fake_openhands()
+        from gandalf_grader.judge import _patch_action_schemas_to_ignore_extra
+
+        # Precondition: extra is forbid.
+        assert Action.model_config.get("extra") == "forbid"
+
+        _patch_action_schemas_to_ignore_extra()
+
+        assert Action.model_config.get("extra") == "ignore"
+        assert TerminalAction.model_config.get("extra") == "ignore"
+        assert FileEditorAction.model_config.get("extra") == "ignore"
+
+    def test_terminal_action_accepts_extra_fields_after_patch(self):
+        _, TerminalAction, _ = self._install_fake_openhands()
+        from gandalf_grader.judge import _patch_action_schemas_to_ignore_extra
+
+        _patch_action_schemas_to_ignore_extra()
+
+        # Should NOT raise -- the extra "evidence" key is silently ignored.
+        obj = TerminalAction(command="ls", evidence=["some data"])  # type: ignore[call-arg]
+        assert obj.command == "ls"
+        # The extra field should not be stored on the model.
+        assert not hasattr(obj, "evidence")
+
+    def test_patch_is_idempotent(self):
+        Action, _, _ = self._install_fake_openhands()
+        from gandalf_grader.judge import _patch_action_schemas_to_ignore_extra
+
+        _patch_action_schemas_to_ignore_extra()
+        _patch_action_schemas_to_ignore_extra()  # second call should be a no-op
+
+        assert Action.model_config.get("extra") == "ignore"


### PR DESCRIPTION
## Problem

When running the gandalf-grader judge agent during Harbor task execution (`harbor run -c job.yaml`), the LLM occasionally includes extra keys in its tool-call arguments. For example, the `evidence` key from the verdict JSON schema leaks into a `terminal` tool call:

```
/tmp/judge_workspace_5ylqejl9/shopify_dcf_model_v1.xlsx; sheet 'Revenue & Income
Forecast' headers: Year, Revenue, Growth Rate, Gross Profit, Operating Income, 
..."]} for tool 'terminal': 1 validation error for TerminalAction
evidence
  Extra inputs are not permitted [type=extra_forbidden, input_value=['Revenue & 
Income Foreca... Operating Income, ..."], input_type=list]
```

### Root cause

The upstream OpenHands SDK defines a `Schema` base class ([source](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/tool/schema.py)) with:

```python
class Schema(DiscriminatedUnionMixin):
    model_config = ConfigDict(extra="forbid", frozen=True)
```

`TerminalAction` inherits `Action → Schema`, so any extra key in a tool call triggers a Pydantic `ValidationError`. Since the judge prompt asks the LLM to produce JSON with `evidence`, `passed`, and `reasoning` fields, the LLM sometimes confuses the verdict schema with the tool-call schema and includes these keys in the terminal tool call arguments.

## Fix

A targeted monkey-patch in `_run_agent_session()` that:

1. Changes `model_config["extra"]` from `"forbid"` to `"ignore"` on the `Action` base class and the two concrete subclasses (`TerminalAction`, `FileEditorAction`)
2. Forces a Pydantic `model_rebuild()` so the compiled validator picks up the new config
3. Is idempotent — skips if already patched

This lets the agent session silently drop spurious keys instead of crashing.

## Test plan

- [x] `test_patch_changes_extra_to_ignore` — verifies `model_config` is updated on all three classes
- [x] `test_terminal_action_accepts_extra_fields_after_patch` — reproduces the exact error scenario (constructing `TerminalAction` with an extra `evidence` key) and confirms it succeeds after patching
- [x] `test_patch_is_idempotent` — calling the patch twice is safe
- [x] All 84 existing tests continue to pass
- [x] `ruff check` passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)