### PR TITLE
Add OTEL tracing support for judge subprocess

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,6 @@ VERIFIER_JUDGE_GUIDANCE_PATH=
 # Example: Langfuse
 #   Encode your keys: echo -n "pk-lf-...:sk-lf-..." | base64
 # ---------------------------------------------------------------------------
-OTEL_EXPORTER_OTLP_ENDPOINT=https://cloud.langfuse.com/api/public/otel
+OTEL_EXPORTER_OTLP_ENDPOINT=https://cloud.langfuse.com/api/public/otel/v1/traces
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20<base64(pk-lf-...:sk-lf-...)>
 OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf

--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,17 @@ LLM_BASE_URL=
 
 # Optional: fallback path to judge guidance file (if not set in verifier TOML)
 VERIFIER_JUDGE_GUIDANCE_PATH=
+
+# ---------------------------------------------------------------------------
+# OpenTelemetry tracing (optional)
+#
+# The OpenHands SDK has built-in OTEL tracing that automatically instruments
+# LLM calls, tool executions, and agent steps. Set these variables to export
+# traces to any OTEL-compatible backend — no code changes required.
+#
+# Example: Langfuse
+#   Encode your keys: echo -n "pk-lf-...:sk-lf-..." | base64
+# ---------------------------------------------------------------------------
+OTEL_EXPORTER_OTLP_ENDPOINT=https://cloud.langfuse.com/api/public/otel
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20<base64(pk-lf-...:sk-lf-...)>
+OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf

--- a/README.md
+++ b/README.md
@@ -133,6 +133,25 @@ For a complete container architecture with task runners and agent environments, 
 | `LLM_API_KEY` | API key for the LLM provider |
 | `LLM_BASE_URL` | Base URL for the LLM API (optional) |
 | `VERIFIER_JUDGE_GUIDANCE_PATH` | Fallback path to judge guidance file (if not set in TOML) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint URL for trace export (optional) |
+| `OTEL_EXPORTER_OTLP_HEADERS` | OTLP auth headers, URL-encoded (optional) |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | OTLP transport protocol, e.g. `http/protobuf` (optional) |
+
+### Tracing / Observability
+
+The OpenHands SDK has built-in OpenTelemetry tracing that automatically instruments LLM calls, tool executions, and agent steps. Set the `OTEL_EXPORTER_OTLP_*` variables above to export traces to any OTEL-compatible backend — no code changes required.
+
+**Example: Langfuse**
+
+```bash
+# Encode your Langfuse keys
+echo -n "pk-lf-...:sk-lf-..." | base64
+
+# Export the variables
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://cloud.langfuse.com/api/public/otel
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic%20<base64-encoded-keys>"
+export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
+```
 
 ## Output
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The OpenHands SDK has built-in OpenTelemetry tracing that automatically instrume
 echo -n "pk-lf-...:sk-lf-..." | base64
 
 # Export the variables
-export OTEL_EXPORTER_OTLP_ENDPOINT=https://cloud.langfuse.com/api/public/otel
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://cloud.langfuse.com/api/public/otel/v1/traces
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic%20<base64-encoded-keys>"
 export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
 ```

--- a/src/gandalf_grader/__main__.py
+++ b/src/gandalf_grader/__main__.py
@@ -48,6 +48,11 @@ _JUDGE_ENV_ALLOWLIST = (
     "UV_TOOL_DIR",
     "UV_TOOL_BIN_DIR",
     "UV_PYTHON_INSTALL_DIR",
+    # OpenTelemetry — forwarded so the inner judge can export traces
+    # to any OTEL-compatible backend (e.g. Langfuse, Jaeger, Honeycomb).
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
 )
 
 


### PR DESCRIPTION
## Summary

- Forward `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, and `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` through the judge env allowlist so the OpenHands SDK's built-in OTEL instrumentation can export traces
- Document the new variables in `.env.example` and `README.md` with a Langfuse example

No new dependencies or code instrumentation — the OpenHands SDK already handles tracing; we just weren't passing the config through.

Resolves [HPT-59](https://linear.app/joinhandshake/issue/HPT-59/add-telemetry-observability-support-to-gandalf)

## Test plan

- [x] All 81 existing tests pass
- [x] Verify traces appear in Langfuse when `OTEL_EXPORTER_OTLP_*` vars are set in a live environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)