### PR TITLE
Improve error reporting for infrastructure failures

### DIFF
--- a/src/gandalf_grader/__main__.py
+++ b/src/gandalf_grader/__main__.py
@@ -159,20 +159,29 @@ def evaluate_criteria(
         _save_trace(trace_path, result.stdout, result.stderr, result.returncode)
 
         if result.returncode != 0:
-            return {
-                "passed": False,
-                "reasoning": f"Judge process failed (exit {result.returncode}): {result.stderr[:500]}",
-            }
+            stderr_tail = result.stderr.strip()[-1000:] if result.stderr else "(empty)"
+            stdout_tail = result.stdout.strip()[-500:] if result.stdout else "(empty)"
+            reason = (
+                f"Judge process failed (exit {result.returncode})\n"
+                f"  stderr: {stderr_tail}\n"
+                f"  stdout (tail): {stdout_tail}"
+            )
+            print(f"[gandalf] {reason}", file=sys.stderr)
+            return {"passed": False, "reasoning": reason}
 
         with open(output_path) as f:
             result_data: dict[str, Any] = json.load(f)
             return result_data
 
     except subprocess.TimeoutExpired:
-        _save_trace(trace_path, "", "Judge execution timed out.", -1)
-        return {"passed": False, "reasoning": "Judge execution timed out."}
+        reason = f"Judge execution timed out after {timeout}s."
+        _save_trace(trace_path, "", reason, -1)
+        print(f"[gandalf] {reason}", file=sys.stderr)
+        return {"passed": False, "reasoning": reason}
     except (json.JSONDecodeError, FileNotFoundError) as e:
-        return {"passed": False, "reasoning": f"Failed to read judge output: {e}"}
+        reason = f"Failed to read judge output: {e}"
+        print(f"[gandalf] {reason}", file=sys.stderr)
+        return {"passed": False, "reasoning": reason}
     finally:
         shutil.rmtree(clone_dir, ignore_errors=True)
         for path in (input_path, output_path):
@@ -257,7 +266,14 @@ def evaluate_all_criteria(
         _save_trace(trace_path, result.stdout, result.stderr, result.returncode)
 
         if result.returncode != 0:
-            reason = f"Judge process failed (exit {result.returncode}): {result.stderr[:500]}"
+            stderr_tail = result.stderr.strip()[-1000:] if result.stderr else "(empty)"
+            stdout_tail = result.stdout.strip()[-500:] if result.stdout else "(empty)"
+            reason = (
+                f"Judge process failed (exit {result.returncode})\n"
+                f"  stderr: {stderr_tail}\n"
+                f"  stdout (tail): {stdout_tail}"
+            )
+            print(f"[gandalf] [batch] {reason}", file=sys.stderr)
             return _fail_all(n_criteria, reason), {}
 
         with open(output_path) as f:
@@ -276,10 +292,14 @@ def evaluate_all_criteria(
             return _fail_all(n_criteria, reason), {}
 
     except subprocess.TimeoutExpired:
-        _save_trace(trace_path, "", "Batch judge execution timed out.", -1)
-        return _fail_all(n_criteria, "Judge execution timed out."), {}
+        reason = f"Batch judge execution timed out after {timeout}s."
+        _save_trace(trace_path, "", reason, -1)
+        print(f"[gandalf] [batch] {reason}", file=sys.stderr)
+        return _fail_all(n_criteria, reason), {}
     except (json.JSONDecodeError, FileNotFoundError, TypeError, AttributeError) as e:
-        return _fail_all(n_criteria, f"Failed to read judge output: {e}"), {}
+        reason = f"Failed to read judge output: {e}"
+        print(f"[gandalf] [batch] {reason}", file=sys.stderr)
+        return _fail_all(n_criteria, reason), {}
     finally:
         shutil.rmtree(clone_dir, ignore_errors=True)
         for path in (input_path, output_path):
@@ -501,9 +521,18 @@ def main() -> None:
     # a legitimate score of 0.0.
     evaluated = any(r.passed or r.evidence for r in results)
     if results and not evaluated:
+        # Collect distinct failure reasons to help diagnose infrastructure issues.
+        unique_reasons = list(dict.fromkeys(r.reasoning for r in results))
+        reasons_block = "\n".join(f"  - {reason}" for reason in unique_reasons[:10])
+
         print(
-            "\nERROR: No criteria were successfully evaluated. "
-            "All failures appear to be infrastructure errors.",
+            f"\nERROR: No criteria were successfully evaluated ({len(results)} criteria, all failed).\n"
+            f"All failures appear to be infrastructure errors.\n"
+            f"\nDistinct failure reasons:\n{reasons_block}\n"
+            f"\nConfig: model={config.model}, mode={config.mode}, "
+            f"sandbox_user={config.sandbox_user}, "
+            f"judge_timeout={config.judge_timeout}s\n"
+            f"Output dir: {config.output_dir} (info.json was still written)",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/src/gandalf_grader/__main__.py
+++ b/src/gandalf_grader/__main__.py
@@ -158,6 +158,11 @@ def evaluate_criteria(
 
         _save_trace(trace_path, result.stdout, result.stderr, result.returncode)
 
+        # Always forward judge stderr so diagnostic output (event logs,
+        # warnings) is visible to the caller regardless of exit code.
+        if result.stderr:
+            sys.stderr.write(result.stderr)
+
         if result.returncode != 0:
             stderr_tail = result.stderr.strip()[-1000:] if result.stderr else "(empty)"
             stdout_tail = result.stdout.strip()[-500:] if result.stdout else "(empty)"
@@ -264,6 +269,11 @@ def evaluate_all_criteria(
         )
 
         _save_trace(trace_path, result.stdout, result.stderr, result.returncode)
+
+        # Always forward judge stderr so diagnostic output (event logs,
+        # warnings) is visible to the caller regardless of exit code.
+        if result.stderr:
+            sys.stderr.write(result.stderr)
 
         if result.returncode != 0:
             stderr_tail = result.stderr.strip()[-1000:] if result.stderr else "(empty)"

--- a/src/gandalf_grader/judge.py
+++ b/src/gandalf_grader/judge.py
@@ -17,6 +17,7 @@ import contextlib
 import json
 import os
 import secrets
+import sys
 import tempfile
 from typing import Any
 
@@ -385,9 +386,15 @@ def run_judge(input_path: str, output_path: str) -> None:
             "llm_usage": llm_usage,
         }
     except Exception as e:
+        import traceback
+
+        tb = traceback.format_exc()
+        error_type = type(e).__name__
+        reason = f"Judge execution error ({error_type}): {e}"
+        print(f"[gandalf-judge] {reason}\n{tb}", file=sys.stderr)
         output = {
             "passed": False,
-            "reasoning": f"Judge execution error: {e}",
+            "reasoning": reason,
             "evidence": [],
             "llm_usage": llm_usage,
         }
@@ -441,10 +448,13 @@ def run_judge_batch(input_path: str, output_path: str) -> None:
         )
         verdicts = _read_batch_verdict(verdict_path, n_criteria)
     except Exception as e:
-        verdicts = _fail_all_verdicts(
-            n_criteria,
-            f"Judge execution error: {e}",
-        )
+        import traceback
+
+        tb = traceback.format_exc()
+        error_type = type(e).__name__
+        reason = f"Judge execution error ({error_type}): {e}"
+        print(f"[gandalf-judge] [batch] {reason}\n{tb}", file=sys.stderr)
+        verdicts = _fail_all_verdicts(n_criteria, reason)
     finally:
         with contextlib.suppress(OSError):
             os.unlink(verdict_path)

--- a/src/gandalf_grader/judge.py
+++ b/src/gandalf_grader/judge.py
@@ -345,6 +345,65 @@ def _summarize_events(conversation: Any) -> str:
     return "\n".join(lines)
 
 
+def _log_agent_diagnostics(agent: Any, llm: Any, model: str) -> None:
+    """Log resolved tool schemas and API path for debugging tool delivery issues.
+
+    Prints to stderr so the outer orchestrator can forward the diagnostics.
+    """
+    lines: list[str] = [f"[gandalf-judge] Agent diagnostics (model={model})"]
+
+    # 1. Which API path is used?
+    try:
+        uses_responses = llm.uses_responses_api()
+        lines.append(f"  api_path: {'responses' if uses_responses else 'chat_completions'}")
+    except Exception as e:
+        lines.append(f"  api_path: unknown ({e})")
+
+    # 2. What tools were resolved after initialization?
+    try:
+        tools_map = agent.tools_map  # dict[str, ToolDefinition]
+        tool_names = sorted(tools_map.keys())
+        lines.append(f"  resolved_tools ({len(tool_names)}): {tool_names}")
+
+        # For each tool, check that the schema has actual parameters
+        for name, tool_def in tools_map.items():
+            try:
+                schema = tool_def.to_openai_tool()
+                func = schema.get("function", {}) if isinstance(schema, dict) else {}
+                params = func.get("parameters", {})
+                prop_count = len(params.get("properties", {})) if isinstance(params, dict) else 0
+                has_desc = bool(func.get("description"))
+                if prop_count == 0 or not has_desc:
+                    lines.append(
+                        f"  WARNING: tool '{name}' has empty schema "
+                        f"(properties={prop_count}, has_description={has_desc})"
+                    )
+            except Exception as e:
+                lines.append(f"  WARNING: tool '{name}' schema extraction failed: {e}")
+    except Exception as e:
+        lines.append(f"  resolved_tools: could not inspect ({e})")
+
+    # 3. Check if responses-path tools differ from chat-completions-path
+    try:
+        uses_responses = llm.uses_responses_api()
+        if uses_responses:
+            for name, tool_def in agent.tools_map.items():
+                try:
+                    resp_schema = tool_def.to_responses_tool()
+                    resp_params = resp_schema.get("parameters", {})
+                    resp_prop_count = len(resp_params.get("properties", {})) if isinstance(resp_params, dict) else 0
+                    if resp_prop_count == 0:
+                        lines.append(
+                            f"  WARNING: tool '{name}' responses_api schema has 0 properties!"
+                        )
+                except Exception as e:
+                    lines.append(f"  WARNING: tool '{name}' responses schema failed: {e}")
+    except Exception:
+        pass
+
+    print("\n".join(lines), file=sys.stderr)
+
+
 def _run_agent_session(
     model: str,
     mcp_servers: list[dict[str, Any]],
@@ -398,6 +457,9 @@ def _run_agent_session(
     conversation = Conversation(agent=agent, workspace=workdir)
     conversation.send_message(prompt)  # type: ignore[attr-defined]
     conversation.run()  # type: ignore[attr-defined]
+
+    # ---------- Diagnostic: tool & API path inspection ----------
+    _log_agent_diagnostics(agent, llm, model)
 
     # Extract execution status
     execution_status = "unknown"

--- a/src/gandalf_grader/judge.py
+++ b/src/gandalf_grader/judge.py
@@ -277,16 +277,85 @@ def _make_verdict_path(prefix: str = "verdict_") -> str:
     )
 
 
+class AgentSessionResult:
+    """Result of an agent session, including usage metrics and event summary."""
+
+    __slots__ = ("llm_usage", "execution_status", "event_summary")
+
+    def __init__(
+        self,
+        llm_usage: dict[str, Any],
+        execution_status: str,
+        event_summary: str,
+    ):
+        self.llm_usage = llm_usage
+        self.execution_status = execution_status
+        self.event_summary = event_summary
+
+
+def _summarize_events(conversation: Any) -> str:
+    """Build a compact human-readable summary of the agent's event log.
+
+    Captures tool calls, their results (truncated), and any errors —
+    exactly the information needed to diagnose why the agent didn't
+    write a verdict file.
+    """
+    from openhands.sdk.event import (
+        ActionEvent,
+        AgentErrorEvent,
+        MessageEvent,
+        ObservationEvent,
+    )
+
+    lines: list[str] = []
+    try:
+        events = conversation.state.events
+        lines.append(f"Events: {len(events)} total")
+
+        for event in events:
+            if isinstance(event, MessageEvent):
+                sender = getattr(event, "sender", "?")
+                msg_text = str(getattr(event, "llm_message", ""))[:200]
+                lines.append(f"  [{sender}] message: {msg_text}")
+
+            elif isinstance(event, ActionEvent):
+                tool = getattr(event, "tool_name", "?")
+                thought = str(getattr(event, "thought", "") or "")[:150]
+                action = str(getattr(event, "action", ""))[:300]
+                lines.append(f"  [action] tool={tool}")
+                if thought:
+                    lines.append(f"    thought: {thought}")
+                lines.append(f"    action: {action}")
+
+            elif isinstance(event, ObservationEvent):
+                tool = getattr(event, "tool_name", "?")
+                obs = str(getattr(event, "observation", ""))
+                # Truncate long observations but keep enough to be useful
+                if len(obs) > 500:
+                    obs = obs[:250] + f"\n    ... ({len(obs)} chars total) ...\n    " + obs[-250:]
+                lines.append(f"  [observation] tool={tool}: {obs}")
+
+            elif isinstance(event, AgentErrorEvent):
+                err = str(getattr(event, "error", ""))[:500]
+                lines.append(f"  [ERROR] {err}")
+
+    except Exception as e:
+        lines.append(f"  (failed to extract events: {e})")
+
+    return "\n".join(lines)
+
+
 def _run_agent_session(
     model: str,
     mcp_servers: list[dict[str, Any]],
     workdir: str,
     prompt: str,
-) -> dict[str, Any]:
+) -> AgentSessionResult:
     """Create an OpenHands agent and run a single conversation.
 
     The agent writes its output to a file (path embedded in *prompt*).
-    Returns a dict of LLM usage metrics (may be empty if extraction fails).
+    Returns an AgentSessionResult with usage metrics, execution status,
+    and a summary of the agent's event log.
     """
     from openhands.sdk import LLM, Agent, Conversation, Tool
     from openhands.tools.file_editor import FileEditorTool
@@ -330,6 +399,17 @@ def _run_agent_session(
     conversation.send_message(prompt)  # type: ignore[attr-defined]
     conversation.run()  # type: ignore[attr-defined]
 
+    # Extract execution status
+    execution_status = "unknown"
+    try:
+        execution_status = str(conversation.state.execution_status)
+    except Exception:
+        pass
+
+    # Extract event summary
+    event_summary = _summarize_events(conversation)
+
+    # Extract LLM usage metrics
     llm_usage: dict[str, Any] = {}
     try:
         token_usage = llm.metrics.accumulated_token_usage
@@ -341,7 +421,12 @@ def _run_agent_session(
         }
     except Exception:
         pass
-    return llm_usage
+
+    return AgentSessionResult(
+        llm_usage=llm_usage,
+        execution_status=execution_status,
+        event_summary=event_summary,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -375,9 +460,20 @@ def run_judge(input_path: str, output_path: str) -> None:
 
     llm_usage: dict[str, Any] = {}
     try:
-        llm_usage = _run_agent_session(
+        session = _run_agent_session(
             judge_input.model, mcp_servers, judge_input.workdir, prompt
         )
+        llm_usage = session.llm_usage
+
+        verdict_exists = os.path.isfile(verdict_path)
+        if not verdict_exists:
+            print(
+                f"[gandalf-judge] Agent did not write verdict file.\n"
+                f"  status: {session.execution_status}\n"
+                f"  agent event log:\n{session.event_summary}",
+                file=sys.stderr,
+            )
+
         verdict = _read_verdict(verdict_path)
         output = {
             "passed": verdict.passed,
@@ -443,9 +539,20 @@ def run_judge_batch(input_path: str, output_path: str) -> None:
 
     llm_usage: dict[str, Any] = {}
     try:
-        llm_usage = _run_agent_session(
+        session = _run_agent_session(
             judge_input.model, mcp_servers, judge_input.workdir, prompt
         )
+        llm_usage = session.llm_usage
+
+        verdict_exists = os.path.isfile(verdict_path)
+        if not verdict_exists:
+            print(
+                f"[gandalf-judge] [batch] Agent did not write verdict file.\n"
+                f"  status: {session.execution_status}\n"
+                f"  agent event log:\n{session.event_summary}",
+                file=sys.stderr,
+            )
+
         verdicts = _read_batch_verdict(verdict_path, n_criteria)
     except Exception as e:
         import traceback


### PR DESCRIPTION
## Summary

When all criteria fail due to infrastructure errors (API key missing, timeouts, judge subprocess crashes), the error messages were opaque — just `"No criteria were successfully evaluated"` with no detail on what actually went wrong. This made debugging batch verifier runs painful, requiring multiple retries before the real error surfaced.

- Include distinct per-criteria failure reasons in the `exit(1)` stderr message, plus config details (model, mode, timeout, sandbox_user)
- Increase stderr capture from 500 to 1000 chars for judge subprocess failures, and include stdout tail
- Print all failure-path errors to stderr so the outer process captures them (timeouts, JSON parse errors, subprocess failures)
- Include exception type and full traceback in `judge.py` error handler instead of just the exception message

### Before
```
ERROR: No criteria were successfully evaluated. All failures appear to be infrastructure errors.
```

### After
```
ERROR: No criteria were successfully evaluated (19 criteria, all failed).
All failures appear to be infrastructure errors.

Distinct failure reasons:
  - Judge execution error (RuntimeError): LLM_API_KEY environment variable is not set...

Config: model=openai/gpt-5.2, mode=sequential, sandbox_user=daytona, judge_timeout=300s
Output dir: /logs/verifier (info.json was still written)
```

## Test plan
- [ ] Run verifier batch with valid config — should succeed as before
- [ ] Run with missing `LLM_API_KEY` — should show the specific RuntimeError in stderr
- [ ] Run with invalid model — should show the API error details
- [ ] Verify `info.json` is still written on infrastructure failures (existing behavior, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)