### PR TITLE
Skip empty agent messages when extracting final output

### DIFF
--- a/src/gandalf_grader/trajectory.py
+++ b/src/gandalf_grader/trajectory.py
@@ -10,9 +10,7 @@ def load_trajectory_final_output(path: str) -> str:
 
     steps = data.get("steps", [])
 
-    # Extract final agent message (last agent message without tool calls
-    # and with non-empty content). Some models emit a trailing assistant
-    # turn containing only reasoning with an empty message field.
+    # Extract final agent message (last with non-empty content, no tool calls)
     final_output = ""
     for step in reversed(steps):
         if step.get("source") == "agent" and not step.get("tool_calls"):

--- a/src/gandalf_grader/trajectory.py
+++ b/src/gandalf_grader/trajectory.py
@@ -10,11 +10,15 @@ def load_trajectory_final_output(path: str) -> str:
 
     steps = data.get("steps", [])
 
-    # Extract final agent message (last agent message without tool calls)
+    # Extract final agent message (last agent message without tool calls
+    # and with non-empty content). Some models emit a trailing assistant
+    # turn containing only reasoning with an empty message field.
     final_output = ""
     for step in reversed(steps):
         if step.get("source") == "agent" and not step.get("tool_calls"):
-            final_output = step.get("message", "")
-            break
+            msg = step.get("message", "")
+            if msg.strip():
+                final_output = msg
+                break
 
     return final_output

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -29,6 +29,41 @@ class TestLoadTrajectoryFinalOutput:
         with pytest.raises(FileNotFoundError):
             load_trajectory_final_output("/nonexistent/trajectory.json")
 
+    def test_skips_trailing_empty_message(self, tmp_path):
+        """When the last agent message has empty content (e.g. reasoning-only
+        turn), the function should return the preceding non-empty message."""
+        p = tmp_path / "trailing_empty.json"
+        p.write_text(json.dumps({
+            "steps": [
+                {"source": "user", "message": "Do the task"},
+                {"source": "agent", "message": "Here is the result."},
+                {"source": "agent", "message": ""},
+            ]
+        }))
+        assert load_trajectory_final_output(str(p)) == "Here is the result."
+
+    def test_skips_trailing_whitespace_only_message(self, tmp_path):
+        p = tmp_path / "trailing_ws.json"
+        p.write_text(json.dumps({
+            "steps": [
+                {"source": "user", "message": "Do the task"},
+                {"source": "agent", "message": "Here is the result."},
+                {"source": "agent", "message": "   \n  "},
+            ]
+        }))
+        assert load_trajectory_final_output(str(p)) == "Here is the result."
+
+    def test_all_agent_messages_empty(self, tmp_path):
+        p = tmp_path / "all_empty.json"
+        p.write_text(json.dumps({
+            "steps": [
+                {"source": "user", "message": "Do the task"},
+                {"source": "agent", "message": ""},
+                {"source": "agent", "message": ""},
+            ]
+        }))
+        assert load_trajectory_final_output(str(p)) == ""
+
     def test_no_agent_messages(self, tmp_path):
         p = tmp_path / "user_only.json"
         p.write_text(json.dumps({


### PR DESCRIPTION
## Summary

- `load_trajectory_final_output()` now skips agent messages with empty or whitespace-only `message` fields when walking backward through trajectory steps
- Some models emit a trailing assistant turn containing only reasoning metadata (no actual content), which previously caused the extractor to return an empty string — even when a valid response existed earlier in the conversation
- Adds 3 new test cases covering trailing empty messages, whitespace-only messages, and all-empty agent messages

## Test plan

- [x] All existing tests pass
- [x] New test: trailing empty message is skipped, returns preceding non-empty message
- [x] New test: trailing whitespace-only message is skipped
- [x] New test: all agent messages empty returns empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)