### PR TITLE
Support remote MCP transports (streamable-http, http, sse)

### DIFF
--- a/src/gandalf/judge.py
+++ b/src/gandalf/judge.py
@@ -237,7 +237,7 @@ def run_agent_session(
     ]
 
     if mcp_servers:
-        mcp_config: dict[str, Any] = {"mcpServers": {srv.name: mcp_server_to_config(srv) for srv in mcp_servers}}
+        mcp_config = {"mcpServers": {srv.name: mcp_server_to_config(srv) for srv in mcp_servers}}
         agent = Agent(llm=llm, tools=tools, mcp_config=mcp_config)
     else:
         agent = Agent(llm=llm, tools=tools)

--- a/src/gandalf/judge.py
+++ b/src/gandalf/judge.py
@@ -181,6 +181,23 @@ def make_verdict_path(prefix: str = "verdict_", directory: str | None = None) ->
     return os.path.join(base, f"{prefix}{secrets.token_hex(8)}.json")
 
 
+def _mcp_server_to_config(srv: MCPServer) -> dict[str, Any]:
+    """Render an MCPServer as the FastMCP MCPConfig server entry shape.
+
+    Stdio servers map to ``{"command": ..., "args": ...}``; remote servers
+    (streamable-http, http, sse) map to ``{"url": ..., "transport": ..., "headers": ...}``.
+    """
+    if srv.transport == "stdio":
+        entry: dict[str, Any] = {"command": srv.command}
+        if srv.args:
+            entry["args"] = srv.args
+        return entry
+    entry = {"url": srv.url, "transport": srv.transport}
+    if srv.headers:
+        entry["headers"] = srv.headers
+    return entry
+
+
 def run_agent_session(
     model: str,
     mcp_servers: list[MCPServer],
@@ -221,9 +238,7 @@ def run_agent_session(
 
     if mcp_servers:
         mcp_config: dict[str, Any] = {
-            "mcpServers": {
-                srv.name: {"command": srv.command, **({"args": srv.args} if srv.args else {})} for srv in mcp_servers
-            }
+            "mcpServers": {srv.name: _mcp_server_to_config(srv) for srv in mcp_servers}
         }
         agent = Agent(llm=llm, tools=tools, mcp_config=mcp_config)
     else:

--- a/src/gandalf/judge.py
+++ b/src/gandalf/judge.py
@@ -237,9 +237,7 @@ def run_agent_session(
     ]
 
     if mcp_servers:
-        mcp_config: dict[str, Any] = {
-            "mcpServers": {srv.name: _mcp_server_to_config(srv) for srv in mcp_servers}
-        }
+        mcp_config: dict[str, Any] = {"mcpServers": {srv.name: _mcp_server_to_config(srv) for srv in mcp_servers}}
         agent = Agent(llm=llm, tools=tools, mcp_config=mcp_config)
     else:
         agent = Agent(llm=llm, tools=tools)

--- a/src/gandalf/judge.py
+++ b/src/gandalf/judge.py
@@ -181,7 +181,7 @@ def make_verdict_path(prefix: str = "verdict_", directory: str | None = None) ->
     return os.path.join(base, f"{prefix}{secrets.token_hex(8)}.json")
 
 
-def _mcp_server_to_config(srv: MCPServer) -> dict[str, Any]:
+def mcp_server_to_config(srv: MCPServer) -> dict[str, Any]:
     """Render an MCPServer as the FastMCP MCPConfig server entry shape.
 
     Stdio servers map to ``{"command": ..., "args": ...}``; remote servers
@@ -237,7 +237,7 @@ def run_agent_session(
     ]
 
     if mcp_servers:
-        mcp_config: dict[str, Any] = {"mcpServers": {srv.name: _mcp_server_to_config(srv) for srv in mcp_servers}}
+        mcp_config: dict[str, Any] = {"mcpServers": {srv.name: mcp_server_to_config(srv) for srv in mcp_servers}}
         agent = Agent(llm=llm, tools=tools, mcp_config=mcp_config)
     else:
         agent = Agent(llm=llm, tools=tools)

--- a/src/gandalf/models.py
+++ b/src/gandalf/models.py
@@ -28,13 +28,12 @@ class MCPServer(BaseModel):
             if not self.command:
                 msg = f"MCP server {self.name!r}: 'command' is required for stdio transport"
                 raise ValueError(msg)
-        else:
-            if not self.url:
-                msg = (
-                    f"MCP server {self.name!r}: 'url' is required for "
-                    f"transport {self.transport!r}"
-                )
-                raise ValueError(msg)
+        elif not self.url:
+            msg = (
+                f"MCP server {self.name!r}: 'url' is required for "
+                f"transport {self.transport!r}"
+            )
+            raise ValueError(msg)
         return self
 
 

--- a/src/gandalf/models.py
+++ b/src/gandalf/models.py
@@ -29,10 +29,7 @@ class MCPServer(BaseModel):
                 msg = f"MCP server {self.name!r}: 'command' is required for stdio transport"
                 raise ValueError(msg)
         elif not self.url:
-            msg = (
-                f"MCP server {self.name!r}: 'url' is required for "
-                f"transport {self.transport!r}"
-            )
+            msg = f"MCP server {self.name!r}: 'url' is required for transport {self.transport!r}"
             raise ValueError(msg)
         return self
 

--- a/src/gandalf/models.py
+++ b/src/gandalf/models.py
@@ -8,15 +8,34 @@ from pydantic import BaseModel, Field, TypeAdapter, model_validator
 
 
 class MCPServer(BaseModel):
-    """Configuration for a stdio MCP server.
+    """Configuration for an MCP server.
 
-    Only stdio transport is supported (OpenHands SDK limitation).
+    Supports stdio (subprocess) and remote network transports
+    (streamable-http, http, sse).  Stdio servers require ``command``;
+    remote servers require ``url``.
     """
 
     name: str
-    transport: Literal["stdio"] = "stdio"
-    command: str
+    transport: Literal["stdio", "streamable-http", "http", "sse"] = "stdio"
+    command: str | None = None
     args: list[str] = Field(default_factory=list)
+    url: str | None = None
+    headers: dict[str, str] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _check_transport_fields(self) -> "MCPServer":
+        if self.transport == "stdio":
+            if not self.command:
+                msg = f"MCP server {self.name!r}: 'command' is required for stdio transport"
+                raise ValueError(msg)
+        else:
+            if not self.url:
+                msg = (
+                    f"MCP server {self.name!r}: 'url' is required for "
+                    f"transport {self.transport!r}"
+                )
+                raise ValueError(msg)
+        return self
 
 
 class RubricItem(BaseModel):

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -137,9 +137,7 @@ class TestMCPServerToConfig:
         assert "args" not in _mcp_server_to_config(srv)
 
     def test_remote_streamable_http(self) -> None:
-        srv = MCPServer(
-            name="x", transport="streamable-http", url="http://localhost:8000/mcp"
-        )
+        srv = MCPServer(name="x", transport="streamable-http", url="http://localhost:8000/mcp")
         assert _mcp_server_to_config(srv) == {
             "url": "http://localhost:8000/mcp",
             "transport": "streamable-http",
@@ -159,9 +157,7 @@ class TestMCPServerToConfig:
         }
 
     def test_remote_omits_empty_headers(self) -> None:
-        srv = MCPServer(
-            name="x", transport="sse", url="http://localhost:8000/sse"
-        )
+        srv = MCPServer(name="x", transport="sse", url="http://localhost:8000/sse")
         assert "headers" not in _mcp_server_to_config(srv)
 
 

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from gandalf.judge import (
+    _mcp_server_to_config,
     build_batch_judge_prompt,
     build_judge_prompt,
     make_verdict_path,
@@ -18,7 +19,7 @@ from gandalf.judge import (
     run_judge,
     run_judge_batch,
 )
-from gandalf.models import LLMUsage
+from gandalf.models import LLMUsage, MCPServer
 from tests.conftest import MOCK_USAGE
 
 
@@ -115,6 +116,53 @@ class TestBuildJudgePrompt:
         output_idx = prompt.index("OUTPUT")
         crit_idx = prompt.index("CRIT")
         assert preamble_idx < guidance_idx < instr_idx < output_idx < crit_idx
+
+
+class TestMCPServerToConfig:
+    """Verify MCPServer is rendered to FastMCP MCPConfig server-entry shape."""
+
+    def test_stdio_minimal(self) -> None:
+        srv = MCPServer(name="x", command="/bin/x")
+        assert _mcp_server_to_config(srv) == {"command": "/bin/x"}
+
+    def test_stdio_with_args(self) -> None:
+        srv = MCPServer(name="x", command="/bin/x", args=["--verbose", "--port", "8000"])
+        assert _mcp_server_to_config(srv) == {
+            "command": "/bin/x",
+            "args": ["--verbose", "--port", "8000"],
+        }
+
+    def test_stdio_omits_empty_args(self) -> None:
+        srv = MCPServer(name="x", command="/bin/x", args=[])
+        assert "args" not in _mcp_server_to_config(srv)
+
+    def test_remote_streamable_http(self) -> None:
+        srv = MCPServer(
+            name="x", transport="streamable-http", url="http://localhost:8000/mcp"
+        )
+        assert _mcp_server_to_config(srv) == {
+            "url": "http://localhost:8000/mcp",
+            "transport": "streamable-http",
+        }
+
+    def test_remote_with_headers(self) -> None:
+        srv = MCPServer(
+            name="x",
+            transport="http",
+            url="https://api.example.com/mcp",
+            headers={"Authorization": "Bearer token"},
+        )
+        assert _mcp_server_to_config(srv) == {
+            "url": "https://api.example.com/mcp",
+            "transport": "http",
+            "headers": {"Authorization": "Bearer token"},
+        }
+
+    def test_remote_omits_empty_headers(self) -> None:
+        srv = MCPServer(
+            name="x", transport="sse", url="http://localhost:8000/sse"
+        )
+        assert "headers" not in _mcp_server_to_config(srv)
 
 
 class TestMakeVerdictPath:

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -10,10 +10,10 @@ from unittest.mock import patch
 import pytest
 
 from gandalf.judge import (
-    _mcp_server_to_config,
     build_batch_judge_prompt,
     build_judge_prompt,
     make_verdict_path,
+    mcp_server_to_config,
     read_batch_verdict,
     read_verdict,
     run_judge,
@@ -123,22 +123,22 @@ class TestMCPServerToConfig:
 
     def test_stdio_minimal(self) -> None:
         srv = MCPServer(name="x", command="/bin/x")
-        assert _mcp_server_to_config(srv) == {"command": "/bin/x"}
+        assert mcp_server_to_config(srv) == {"command": "/bin/x"}
 
     def test_stdio_with_args(self) -> None:
         srv = MCPServer(name="x", command="/bin/x", args=["--verbose", "--port", "8000"])
-        assert _mcp_server_to_config(srv) == {
+        assert mcp_server_to_config(srv) == {
             "command": "/bin/x",
             "args": ["--verbose", "--port", "8000"],
         }
 
     def test_stdio_omits_empty_args(self) -> None:
         srv = MCPServer(name="x", command="/bin/x", args=[])
-        assert "args" not in _mcp_server_to_config(srv)
+        assert "args" not in mcp_server_to_config(srv)
 
     def test_remote_streamable_http(self) -> None:
         srv = MCPServer(name="x", transport="streamable-http", url="http://localhost:8000/mcp")
-        assert _mcp_server_to_config(srv) == {
+        assert mcp_server_to_config(srv) == {
             "url": "http://localhost:8000/mcp",
             "transport": "streamable-http",
         }
@@ -150,7 +150,7 @@ class TestMCPServerToConfig:
             url="https://api.example.com/mcp",
             headers={"Authorization": "Bearer token"},
         )
-        assert _mcp_server_to_config(srv) == {
+        assert mcp_server_to_config(srv) == {
             "url": "https://api.example.com/mcp",
             "transport": "http",
             "headers": {"Authorization": "Bearer token"},
@@ -158,7 +158,7 @@ class TestMCPServerToConfig:
 
     def test_remote_omits_empty_headers(self) -> None:
         srv = MCPServer(name="x", transport="sse", url="http://localhost:8000/sse")
-        assert "headers" not in _mcp_server_to_config(srv)
+        assert "headers" not in mcp_server_to_config(srv)
 
 
 class TestMakeVerdictPath:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -115,10 +115,48 @@ class TestPydanticModels:
         srv = MCPServer(name="test", command="/bin/test")
         assert srv.transport == "stdio"
         assert srv.args == []
+        assert srv.url is None
+        assert srv.headers == {}
 
-    def test_mcp_server_rejects_non_stdio_transport(self) -> None:
+    def test_mcp_server_stdio_requires_command(self) -> None:
+        with pytest.raises(ValidationError, match="'command' is required"):
+            MCPServer(name="test")
+
+    def test_mcp_server_remote_streamable_http(self) -> None:
+        srv = MCPServer(
+            name="remote",
+            transport="streamable-http",
+            url="http://localhost:8000/mcp",
+        )
+        assert srv.transport == "streamable-http"
+        assert srv.url == "http://localhost:8000/mcp"
+        assert srv.command is None
+
+    def test_mcp_server_remote_http_with_headers(self) -> None:
+        srv = MCPServer(
+            name="remote",
+            transport="http",
+            url="https://api.example.com/mcp",
+            headers={"Authorization": "Bearer token"},
+        )
+        assert srv.transport == "http"
+        assert srv.headers == {"Authorization": "Bearer token"}
+
+    def test_mcp_server_remote_sse(self) -> None:
+        srv = MCPServer(
+            name="remote",
+            transport="sse",
+            url="http://localhost:8000/sse",
+        )
+        assert srv.transport == "sse"
+
+    def test_mcp_server_remote_requires_url(self) -> None:
+        with pytest.raises(ValidationError, match="'url' is required"):
+            MCPServer(name="remote", transport="streamable-http")
+
+    def test_mcp_server_rejects_unknown_transport(self) -> None:
         with pytest.raises(ValidationError):
-            MCPServer(name="test", command="/bin/test", transport="sse")  # type: ignore[arg-type]
+            MCPServer(name="test", command="/bin/test", transport="grpc")  # type: ignore[arg-type]
 
     def test_grader_config_has_trajectory_path(self) -> None:
         cfg = GraderConfig(


### PR DESCRIPTION
## Summary

The `MCPServer` model previously only accepted `stdio`, citing an OpenHands SDK limitation that no longer holds. OpenHands forwards `mcp_config` verbatim to FastMCP's `MCPConfig`, which supports both stdio and remote transports.

This PR extends `MCPServer` to support remote MCP servers (`streamable-http`, `http`, `sse`) alongside stdio. Existing stdio task.toml files keep working unchanged.

## Motivation

We need this in the BTB Harbor environment for Prime Intellect, where the MCP server runs as a long-lived HTTP service inside the sandbox (rather than a per-judge-session subprocess). Without remote transport support in gandalf, the verifier can't connect to that server, and we end up running two separate MCP processes per rollout with bespoke port allocation and sed-based grader.toml patching.

## Changes

- ` src/gandalf/models.py`
  - `MCPServer.transport` literal broadened to `Literal["stdio", "streamable-http", "http", "sse"]`
  - `command` is now optional; new optional fields `url` and `headers`
  - `model_validator` enforces `command` for stdio and `url` for remote
  - Updated docstring (the OpenHands-limitation claim was outdated)
- `src/gandalf/judge.py`
  - New `_mcp_server_to_config` helper that branches on transport when emitting the FastMCP `mcpServers` entry
  - `run_agent_session` uses the helper instead of inline stdio-only construction
- `tests/test_models.py` — adds 6 tests for remote-transport parsing + validation
- `tests/test_judge.py` — adds 6 tests for `_mcp_server_to_config` covering stdio and remote shapes

## Backwards compatibility

100% backwards compatible. Existing `[[mcp_servers]]` entries with `transport = "stdio"` and `command = ...` parse and emit identically.

## Test plan

- [x] All 127 existing tests still pass
- [x] 12 new tests pass and cover both transport families
- [x] Lint passes (`ruff check`)