### PR TITLE
Add grading guidance mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 .coverage
 htmlcov/
 site/
+_run/
 *.egg
 .hatch/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Read the [launch blog post](https://joinhandshake.com/research/ai/gandalf-the-grader/) for the motivation, benchmark results, and design rationale behind Gandalf.
 
-Gandalf is a reactive agent-as-judge for rubric-graded agent environments. Given a rubric of binary criteria, it runs inside the rollout environment, uses the same tools as the rollout agent, and decides at inference time which files to open and which tool state to query.
+Gandalf is a reactive agent-as-judge for agent environments. In its default rubric mode, it grades binary criteria and computes a weighted reward. In guidance mode, it uses free-form grading guidance to assign one holistic score in `[0, 1]`. In both modes, it runs inside the rollout environment, uses the same tools as the rollout agent, and decides at inference time which files to open and which tool state to query.
 
 That lets Gandalf grade criteria that depend on artifacts or state — formulas in a workbook, charts in a deck, files on disk, MCP tool state, or whether an email was actually sent — rather than just the final text response.
 
@@ -63,28 +63,37 @@ Expected verdicts: the `welcome.txt` file exists (met), the message mentions Gan
 
 The example uses [`gemini/gemini-2.5-flash`](examples/quickstart/grader.toml) and runs the inner judge as the current user (no `sandbox_user`, no sudo). To adapt it to your own setup, edit [`examples/quickstart/grader.toml`](examples/quickstart/grader.toml). See the [Configuration](#configuration) section below for the full field reference.
 
+The same fixture can also be graded holistically with free-form guidance:
+
+```bash
+gandalf-the-grader --config examples/quickstart/guidance_grader.toml
+cat examples/quickstart/guidance_output/reward.json
+cat examples/quickstart/guidance_output/info.json
+```
+
 ## Configuration
 
 ### `grader.toml`
 
 | Field | Required | Default | Description |
 |---|---|---|---|
+| `grading_mode` | No | `rubric` | Grading path: `rubric` for weighted criteria, or `guidance` for one holistic score |
 | `instructions` | Yes\* | | Inline task instructions given to the original agent (mutually exclusive with `instructions_path`) |
 | `instructions_path` | Yes\* | | Path to a file with task instructions (mutually exclusive with `instructions`) |
-| `rubric` | Yes\* | | Inline rubric as a TOML array of tables (mutually exclusive with `rubric_path`) |
-| `rubric_path` | Yes\* | | Path to rubric JSON file (mutually exclusive with `rubric`) |
-| `judge_guidance` | No | | Inline judge guidance text (mutually exclusive with `judge_guidance_path`) |
-| `judge_guidance_path` | No | | Path to a file with extra judge instructions (mutually exclusive with `judge_guidance`) |
+| `rubric` | Rubric mode\* | | Inline rubric as a TOML array of tables (mutually exclusive with `rubric_path`; invalid in guidance mode) |
+| `rubric_path` | Rubric mode\* | | Path to rubric JSON file (mutually exclusive with `rubric`; invalid in guidance mode) |
+| `judge_guidance` | Guidance mode\* | | Inline judge guidance text (mutually exclusive with `judge_guidance_path`; optional extra context in rubric mode) |
+| `judge_guidance_path` | Guidance mode\* | | Path to a file with extra judge instructions (mutually exclusive with `judge_guidance`; optional extra context in rubric mode) |
 | `workdir` | Yes | | Agent workspace directory |
 | `trajectory_path` | Yes | | Path to ATIF trajectory JSON |
 | `output_dir` | Yes | | Directory for grader output files |
 | `model` | No | `gemini/gemini-2.5-flash` | LLM model for the judge agent |
-| `mode` | No | `batch` | Evaluation mode: `batch` or `individual` |
+| `mode` | No | `batch` | Rubric evaluation mode: `batch` or `individual` |
 | `judge_timeout` | No | `300` | Max seconds per judge invocation |
-| `batch_timeout` | No | | Max total seconds for batch mode (caps `judge_timeout * N`) |
-| `judge_retries` | No | `1` | Number of retry attempts for criteria that error due to infrastructure failures |
-| `batch_splits` | No | | Split criteria into N chunks in batch mode (>= 2). Each chunk is evaluated as a separate batch session. Only valid with `mode = "batch"`. |
-| `max_concurrency` | No | | Max parallel judge sessions (>= 1). Defaults to 1 for individual mode, `batch_splits` for batch mode. |
+| `batch_timeout` | No | | Rubric batch-mode max total seconds (caps `judge_timeout * N`; invalid in guidance mode) |
+| `judge_retries` | No | `1` | Number of retry attempts for criteria or guidance scores that error due to infrastructure/parse failures |
+| `batch_splits` | No | | Split rubric criteria into N chunks in batch mode (>= 2). Only valid with `mode = "batch"` and rubric mode. |
+| `max_concurrency` | No | | Max parallel rubric judge sessions (>= 1). Invalid in guidance mode. |
 | `sandbox_user` | No | | Username for running the inner judge (via sudo). When omitted the judge runs as the current user. |
 | `judge_prompt` | No | | Inline Jinja2 template that completely overrides the built-in judge task prompt (mutually exclusive with `judge_prompt_path`) |
 | `judge_prompt_path` | No | | Path to a Jinja2 template file that completely overrides the built-in judge task prompt (mutually exclusive with `judge_prompt`) |
@@ -111,14 +120,31 @@ The template receives these variables:
 
 | Variable | Type | Mode | Description |
 |---|---|---|---|
-| `instructions` | `str` | both | Task instructions given to the original agent |
-| `final_output` | `str` | both | Agent's final message from the trajectory |
+| `instructions` | `str` | all | Task instructions given to the original agent |
+| `final_output` | `str` | all | Agent's final message from the trajectory |
 | `criterion` | `str` | individual | The single criterion string to evaluate |
 | `criteria` | `list[str]` | batch | List of all criterion strings to evaluate |
-| `verdict_path` | `str` | both | File path the judge must write its verdict to |
-| `judge_guidance` | `str` | both | Additional guidance text (may be empty) |
+| `verdict_path` | `str` | individual, batch | File path the judge must write its verdict to |
+| `judge_guidance` | `str` | all | Additional guidance text; required in guidance mode |
+| `trajectory_path` | `str` | guidance | Path to the copied trajectory JSON inside the cloned judge workspace |
+| `score_path` | `str` | guidance | File path the judge must write its holistic score to |
 
-Individual and batch modes use separate built-in templates. In a custom template, use `{% if criterion is defined %}` vs `{% if criteria is defined %}` if you need to distinguish modes. In batch mode, use `loop.index0` for the criterion index (e.g., `{% for c in criteria %}[{{ loop.index0 }}] {{ c }}{% endfor %}`).
+Individual, batch, and guidance modes use separate built-in templates. In a custom template, use `{% if criterion is defined %}`, `{% if criteria is defined %}`, or `{% if score_path is defined %}` if you need to distinguish modes. In batch mode, use `loop.index0` for the criterion index (e.g., `{% for c in criteria %}[{{ loop.index0 }}] {{ c }}{% endfor %}`).
+
+### Guidance Mode
+
+Set `grading_mode = "guidance"` to grade with free-form guidance instead of a rubric:
+
+```toml
+grading_mode = "guidance"
+instructions_path = "/path/to/instruction.md"
+judge_guidance_path = "/path/to/judge_guidance.md"
+workdir = "/path/to/final/workspace"
+trajectory_path = "/path/to/agent/trajectory.json"
+output_dir = "/path/to/grader-output"
+```
+
+Guidance mode rejects `rubric`, `rubric_path`, `batch_splits`, `batch_timeout`, and `max_concurrency` so those fields are not silently ignored. It runs one holistic judge session per attempt. The judge sees the final output as context, but the full trajectory JSON is copied into the cloned judge workspace and passed as `trajectory_path`; the full trajectory is not inlined into the prompt.
 
 ### Rubric JSON
 
@@ -183,13 +209,50 @@ export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
 
 ## Output
 
-The grader writes to `output_dir`:
+In rubric mode, the grader writes to `output_dir`:
 
 - `reward.json`: Reward file (e.g., `{"reward": 0.75}`) (always in [0, 1]). **Only written when all criteria are successfully evaluated.** If any criteria still have errors after retries, the grader writes `info.json` but skips `reward.json` and exits with code 1.
 - `info.json`: Always written. Per-criterion results with `met`/not-met, reasoning, evidence, LLM usage, plus `reward`, `raw_score`, `minimum_score`, `maximum_score`, `errored_criterion_count`, and `evaluated_criteria_pct`.
 - `judge_trace_*.txt`: stdout/stderr capture for each judge invocation. Naming varies by mode: `judge_trace_{i}.txt` (individual), `judge_trace_batch.txt` (batch), `judge_trace_batch_split{i}.txt` (batch with splits). Retries append a `_retry{N}` suffix.
 
 The `reward` in `reward.json` is `clip(0, 1, raw_score / sum_of_positive_weights)`, always in [0, 1]. `info.json` additionally includes `raw_score` (the raw sum of weights for met criteria, which can be negative) and `minimum_score`/`maximum_score` bounds for reference.
+
+In guidance mode:
+
+- `reward.json`: `{"reward": <score>}` where score is the holistic judge score rounded to 4 decimals. Only written when the judge returns a valid numeric score in `[0, 1]`.
+- `info.json`: Always written after the guidance judge runs. Contains `grading_mode`, `reward`, `score`, `reasoning`, `evidence`, `llm_usage`, `errored`, and `error`.
+- `judge_trace_guidance*.txt`: stdout/stderr capture for each holistic judge attempt. Retries are named `judge_trace_guidance_retry{N}.txt`.
+
+The guidance judge output is considered valid only when it includes a numeric score, non-empty reasoning, and a non-empty evidence array. Missing or malformed audit fields are treated like invalid judge output and retried according to `judge_retries`. The default guidance prompt asks the judge to include artifact evidence, trajectory evidence, and an explicit score calibration/cap audit so score bands and hard penalties from the guidance are applied visibly. It also asks the judge to reconcile conflicts between the task instructions and grading guidance, especially artifact output-location conflicts, before applying path-related penalties. When tasks mention required or forbidden external actions, the prompt asks for an action/side-effect audit based on trajectory tool calls and final state.
+
+Example guidance `info.json`:
+
+```json
+{
+  "grading_mode": "guidance",
+  "reward": 0.8,
+  "score": 0.8,
+  "reasoning": "The final artifact is mostly correct but omits one requested comparison.",
+  "evidence": ["Read /workspace/report.md", "Inspected trajectory file for failed command"],
+  "llm_usage": {"cost_usd": 0.02, "prompt_tokens": 1200, "completion_tokens": 400, "cache_read_tokens": 0},
+  "errored": false,
+  "error": null
+}
+```
+
+## Harbor Rollouts and DSPy Calibration
+
+The repo includes helper scripts for collecting Harbor rollouts without running any verifier, then evaluating rubric and guidance scoring later. The analysis helper reports rubric/guidance score agreement as a calibration signal, plus guidance-grounded audit signals such as guidance vocabulary coverage, trajectory evidence, score-cap audit evidence, output-location conflict audits, and required-action evidence:
+
+```bash
+scripts/collect_harbor_rollouts.sh
+scripts/index_harbor_rollouts.py
+scripts/eval_guidance_scores.py --mode rubric
+scripts/eval_guidance_scores.py --mode guidance
+uv run --group eval scripts/dspy_optimize_guidance.py
+```
+
+`collect_harbor_rollouts.sh` sources `$ENV_FILE` (default: `$HOME/Downloads/env`), discovers Harbor-format tasks under `$TASK_ROOT` (default: `$HOME/Downloads/harbor-research-v2-Batch1-2`), runs `harbor run` with `--disable-verification`, and caps outer concurrency at 5. DSPy is used only by the evaluation/calibration script; Gandalf's runtime guidance mode remains the reactive environment-inspecting judge.
 
 ## Next steps
 

--- a/examples/quickstart/.gitignore
+++ b/examples/quickstart/.gitignore
@@ -1,1 +1,2 @@
 output/
+guidance_output/

--- a/examples/quickstart/guidance_grader.toml
+++ b/examples/quickstart/guidance_grader.toml
@@ -1,0 +1,9 @@
+model = "gemini/gemini-2.5-flash"
+grading_mode = "guidance"
+
+instructions = "Create a welcome.txt file that greets Gandalf in a short message."
+judge_guidance_path = "examples/quickstart/judge_guidance.md"
+
+workdir = "examples/quickstart/workspace"
+trajectory_path = "examples/quickstart/trajectory.json"
+output_dir = "examples/quickstart/guidance_output"

--- a/examples/quickstart/judge_guidance.md
+++ b/examples/quickstart/judge_guidance.md
@@ -1,0 +1,5 @@
+Grade the task holistically from 0 to 1.
+
+A perfect score should require that the final workspace contains `welcome.txt`, the file greets or mentions Gandalf, and the message is short and directly responsive to the task. Give partial credit when the file exists but misses one of those expectations. Give little or no credit if the file is absent or unrelated.
+
+Use both the current workspace state and the trajectory file to understand what the agent actually did.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ name = "pinned"
 
 [dependency-groups]
 dev = ["pytest>=8.0", "ruff>=0.15.0", "mypy>=1.19.0"]
+eval = ["dspy-ai>=3.2,<4"]
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.12", "3.13", "3.14"]

--- a/scripts/analyze_guidance_eval.py
+++ b/scripts/analyze_guidance_eval.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python3
+"""Analyze guidance-mode scoring quality with guidance-grounded audit signals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+from gandalf.guidance_evidence import (
+    extract_score_calibration_ceiling,
+    has_action_side_effect_audit,
+    has_output_location_conflict_audit,
+    has_score_calibration_audit,
+    has_source_availability_audit,
+    has_source_guidance_conflict_language,
+    has_source_verification_audit,
+    has_trajectory_evidence,
+    has_workspace_artifact_evidence,
+    requires_above_midpoint_justification,
+    requires_action_side_effect_audit,
+    requires_output_location_conflict_audit,
+    requires_source_availability_audit,
+    requires_source_verification_audit,
+)
+
+MIN_CORRELATION_POINTS = 2
+MIN_RUBRIC_ALIGNMENT_TOKENS = 20
+RUBRIC_TASK_MISMATCH_COVERAGE_THRESHOLD = 0.5
+RUBRIC_LANGUAGE_RE = re.compile(r"\brubrics?\b", re.IGNORECASE)
+GUIDANCE_RETRY_RE = re.compile(
+    r"^\[retry\s+\d+/\d+\]\s+Retrying guidance score",
+    re.IGNORECASE | re.MULTILINE,
+)
+FORMULA_CACHE_SOURCE_AUDIT_RE = re.compile(
+    r"\bformula cache/source-value audit\b"
+    r"|\bformulas?\s+without\s+cached\s+values?\b"
+    r"|\bno\s+cached\s+values?\b"
+    r"|\buncached\s+formulas?\b"
+    r"|\b(?:posted|displayed)\s+(?:book-of-record\s+)?(?:actuals?|values?)\b",
+    re.IGNORECASE,
+)
+
+STOPWORDS = {
+    "about",
+    "actual",
+    "agent",
+    "also",
+    "analysis",
+    "and",
+    "from",
+    "have",
+    "into",
+    "that",
+    "the",
+    "their",
+    "this",
+    "with",
+    "workbook",
+}
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load JSON Lines into a list of dictionaries."""
+    with path.open() as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def load_json(path: str | Path) -> dict[str, Any]:
+    """Load a JSON object, returning an empty dict on missing/invalid input."""
+    try:
+        with Path(path).open() as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def load_json_any(path: str | Path) -> Any:
+    """Load JSON data, returning None on missing/invalid input."""
+    try:
+        with Path(path).open() as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError, TypeError):
+        return None
+
+
+def result_key(record: dict[str, Any]) -> tuple[str, str]:
+    """Stable key shared by manifest and eval result records."""
+    return str(record.get("slug", "")), str(record.get("trial_dir", ""))
+
+
+def tokens(text: str) -> set[str]:
+    """Tokenize text into content-ish words."""
+    return {tok for tok in re.findall(r"[a-zA-Z][a-zA-Z0-9_-]{3,}", text.lower()) if tok not in STOPWORDS}
+
+
+def read_text_path(path: str | Path) -> str:
+    """Read a text file, returning an empty string on missing/invalid input."""
+    try:
+        return Path(path).read_text()
+    except (OSError, TypeError):
+        return ""
+
+
+def safe_float(value: Any) -> float:
+    """Coerce a value to float, returning 0 for missing/invalid input."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def safe_int(value: Any) -> int:
+    """Coerce a value to int, returning 0 for missing/invalid input."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def guidance_retry_count(result: dict[str, Any]) -> int:
+    """Count guidance judge retry attempts recorded in a trial eval stdout file."""
+    eval_dir = result.get("eval_dir")
+    if not eval_dir:
+        return 0
+    return len(GUIDANCE_RETRY_RE.findall(read_text_path(Path(str(eval_dir)) / "stdout.txt")))
+
+
+def guidance_usage_metrics(info: dict[str, Any]) -> dict[str, Any]:
+    """Extract additive LLM usage metrics from guidance info.json."""
+    usage = info.get("llm_usage", {})
+    if not isinstance(usage, dict):
+        usage = {}
+    return {
+        "guidance_llm_cost_usd": round(safe_float(usage.get("cost_usd")), 4),
+        "guidance_prompt_tokens": safe_int(usage.get("prompt_tokens")),
+        "guidance_completion_tokens": safe_int(usage.get("completion_tokens")),
+        "guidance_cache_read_tokens": safe_int(usage.get("cache_read_tokens")),
+    }
+
+
+def guidance_tokens(record: dict[str, Any]) -> set[str]:
+    """Load and tokenize free-form grading guidance for a manifest record."""
+    text = read_text_path(record.get("judge_guidance_path", ""))
+    return tokens(text)
+
+
+def extract_rubric_text(data: Any) -> str:
+    """Extract human-readable criterion text from supported rubric JSON shapes."""
+    if isinstance(data, list):
+        parts = []
+        for item in data:
+            if isinstance(item, dict):
+                criterion = item.get("criterion")
+                if criterion is not None:
+                    parts.append(str(criterion))
+            elif isinstance(item, str):
+                parts.append(item)
+        return " ".join(parts)
+    if isinstance(data, dict):
+        criteria = data.get("criteria")
+        if criteria is not None:
+            return extract_rubric_text(criteria)
+        criterion = data.get("criterion")
+        if criterion is not None:
+            return str(criterion)
+    return ""
+
+
+def rubric_tokens(record: dict[str, Any]) -> set[str]:
+    """Load and tokenize rubric criterion text for a manifest record."""
+    return tokens(extract_rubric_text(load_json_any(record.get("rubric_path", ""))))
+
+
+def task_context_tokens(record: dict[str, Any]) -> set[str]:
+    """Tokenize the task-facing context that a matching rubric should describe."""
+    text = "\n".join(
+        [
+            read_text_path(record.get("instruction_path", "")),
+            read_text_path(record.get("judge_guidance_path", "")),
+        ]
+    )
+    return tokens(text)
+
+
+def rubric_alignment_metrics(record: dict[str, Any]) -> dict[str, Any]:
+    """Estimate whether a rubric appears to describe the same task as the manifest record."""
+    rubric = rubric_tokens(record)
+    task_context = task_context_tokens(record)
+    coverage = len(rubric & task_context) / len(rubric) if rubric else 0.0
+    potential_mismatch = (
+        len(rubric) >= MIN_RUBRIC_ALIGNMENT_TOKENS
+        and bool(task_context)
+        and coverage < RUBRIC_TASK_MISMATCH_COVERAGE_THRESHOLD
+    )
+    return {
+        "rubric_task_vocab_coverage": round(coverage, 4),
+        "potential_rubric_task_mismatch": potential_mismatch,
+    }
+
+
+def info_text(info: dict[str, Any]) -> str:
+    """Concatenate guidance reasoning and evidence text."""
+    evidence = info.get("evidence", [])
+    if not isinstance(evidence, list):
+        evidence = [str(evidence)]
+    return " ".join([str(info.get("reasoning", "")), *[str(item) for item in evidence]])
+
+
+def evidence_metrics(info: dict[str, Any], record: dict[str, Any]) -> dict[str, Any]:
+    """Compute non-score signals for guidance reasoning/evidence."""
+    evidence = info.get("evidence", [])
+    if not isinstance(evidence, list):
+        evidence = [str(evidence)] if evidence else []
+    combined = info_text(info)
+    combined_lower = combined.lower()
+    guidance = guidance_tokens(record)
+    g_tokens = tokens(combined)
+    coverage = len(guidance & g_tokens) / len(guidance) if guidance else 0.0
+    has_file_or_path = has_workspace_artifact_evidence([str(item) for item in evidence])
+    mentions_trajectory = has_trajectory_evidence([str(item) for item in evidence])
+    mentions_score_calibration = has_score_calibration_audit([str(item) for item in evidence])
+    declared_score_ceiling = extract_score_calibration_ceiling([str(item) for item in evidence])
+    mentions_output_location_audit = has_output_location_conflict_audit([str(item) for item in evidence])
+    mentions_action_side_effect_audit = has_action_side_effect_audit([str(item) for item in evidence])
+    mentions_source_availability_audit = has_source_availability_audit([str(item) for item in evidence])
+    mentions_source_verification_audit = has_source_verification_audit([str(item) for item in evidence])
+    mentions_rubric_language = bool(RUBRIC_LANGUAGE_RE.search(combined))
+    mentions_source_guidance_conflict = any(
+        has_source_guidance_conflict_language(str(item)) for item in [info.get("reasoning", ""), *evidence]
+    )
+    mentions_formula_cache_source_audit = bool(FORMULA_CACHE_SOURCE_AUDIT_RE.search(combined))
+    instructions_text = read_text_path(record.get("instruction_path", ""))
+    guidance_text = read_text_path(record.get("judge_guidance_path", ""))
+    requires_action_check = requires_action_side_effect_audit(
+        instructions_text,
+        guidance_text,
+    )
+    requires_output_location_check = requires_output_location_conflict_audit(
+        instructions_text,
+        guidance_text,
+    )
+    requires_source_availability_check = requires_source_availability_audit(
+        instructions_text,
+        guidance_text,
+    )
+    requires_source_verification_check = requires_source_verification_audit(
+        instructions_text,
+        guidance_text,
+    )
+    mentions_action_or_side_effect = any(
+        term in combined_lower
+        for term in [
+            "draft",
+            "sent",
+            "send",
+            "email",
+            "outlook",
+            "calendar",
+            "live action",
+            "side effect",
+            "quickbooks",
+            "shopify",
+            "square",
+        ]
+    )
+    evidence_count = len(evidence)
+    baseline_evidence_quality = (
+        min(1.0, evidence_count / 3.0) * 0.5
+        + (0.25 if has_file_or_path else 0.0)
+        + (0.25 if mentions_trajectory else 0.0)
+    )
+    required_audits = [mentions_score_calibration]
+    if requires_output_location_check:
+        required_audits.append(mentions_output_location_audit)
+    if requires_action_check:
+        required_audits.append(mentions_action_side_effect_audit)
+    if requires_source_availability_check:
+        required_audits.append(mentions_source_availability_audit)
+    if requires_source_verification_check:
+        required_audits.append(mentions_source_verification_audit)
+    required_audit_coverage = mean([1.0 if audit_present else 0.0 for audit_present in required_audits])
+    evidence_quality = baseline_evidence_quality * 0.75 + required_audit_coverage * 0.25
+    return {
+        "evidence_count": evidence_count,
+        "has_file_or_path_evidence": has_file_or_path,
+        "mentions_trajectory_or_tools": mentions_trajectory,
+        "guidance_vocab_coverage": round(coverage, 4),
+        "mentions_score_calibration_cap_audit": mentions_score_calibration,
+        "declared_score_ceiling": round(declared_score_ceiling, 4) if declared_score_ceiling is not None else None,
+        "mentions_output_location_conflict_audit": mentions_output_location_audit,
+        "requires_output_location_conflict_check": requires_output_location_check,
+        "mentions_action_side_effect_audit": mentions_action_side_effect_audit,
+        "requires_action_or_side_effect_check": requires_action_check,
+        "mentions_source_availability_audit": mentions_source_availability_audit,
+        "requires_source_availability_check": requires_source_availability_check,
+        "mentions_source_verification_audit": mentions_source_verification_audit,
+        "requires_source_verification_check": requires_source_verification_check,
+        "mentions_rubric_language": mentions_rubric_language,
+        "mentions_source_guidance_conflict": mentions_source_guidance_conflict,
+        "mentions_formula_cache_source_audit": mentions_formula_cache_source_audit,
+        "mentions_action_or_side_effects": mentions_action_or_side_effect,
+        "baseline_evidence_quality": round(baseline_evidence_quality, 4),
+        "required_audit_coverage": round(required_audit_coverage, 4),
+        "evidence_quality": round(evidence_quality, 4),
+    }
+
+
+def mean(values: list[float]) -> float:
+    """Return arithmetic mean, or 0 for empty input."""
+    return sum(values) / len(values) if values else 0.0
+
+
+def pearson(xs: list[float], ys: list[float]) -> float | None:
+    """Compute Pearson correlation without external dependencies."""
+    if len(xs) < MIN_CORRELATION_POINTS or len(xs) != len(ys):
+        return None
+    x_mean = mean(xs)
+    y_mean = mean(ys)
+    num = sum((x - x_mean) * (y - y_mean) for x, y in zip(xs, ys, strict=True))
+    den_x = math.sqrt(sum((x - x_mean) ** 2 for x in xs))
+    den_y = math.sqrt(sum((y - y_mean) ** 2 for y in ys))
+    if den_x == 0 or den_y == 0:
+        return None
+    return num / (den_x * den_y)
+
+
+def ranks(values: list[float]) -> list[float]:
+    """Return average ranks for values."""
+    ordered = sorted(enumerate(values), key=lambda item: item[1])
+    out = [0.0] * len(values)
+    i = 0
+    while i < len(ordered):
+        j = i + 1
+        while j < len(ordered) and ordered[j][1] == ordered[i][1]:
+            j += 1
+        rank = (i + j - 1) / 2.0 + 1
+        for k in range(i, j):
+            out[ordered[k][0]] = rank
+        i = j
+    return out
+
+
+def joined_rows(
+    manifest: list[dict[str, Any]],
+    rubric_results: list[dict[str, Any]],
+    guidance_results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Join manifest, rubric result, and guidance result rows."""
+    manifest_by_key = {result_key(record): record for record in manifest}
+    rubric_by_key = {result_key(row): row for row in rubric_results}
+    guidance_by_key = {result_key(row): row for row in guidance_results}
+    rows: list[dict[str, Any]] = []
+    for key, record in manifest_by_key.items():
+        rubric = rubric_by_key.get(key)
+        guidance = guidance_by_key.get(key)
+        if not rubric or not guidance:
+            continue
+        rubric_reward = rubric.get("reward")
+        guidance_reward = guidance.get("reward")
+        if rubric_reward is None or guidance_reward is None:
+            continue
+        guidance_info = load_json(guidance.get("info_path", ""))
+        evidence = evidence_metrics(guidance_info, record)
+        retry_count = guidance_retry_count(guidance)
+        usage_metrics = guidance_usage_metrics(guidance_info)
+        rubric_alignment = rubric_alignment_metrics(record)
+        declared_score_ceiling = evidence["declared_score_ceiling"]
+        exceeds_declared_ceiling = declared_score_ceiling is not None and float(guidance_reward) > float(
+            declared_score_ceiling
+        )
+        near_ceiling_with_foundational_failure = requires_above_midpoint_justification(
+            float(guidance_reward),
+            float(declared_score_ceiling) if declared_score_ceiling is not None else None,
+            reasoning=str(guidance_info.get("reasoning", "")),
+            evidence=[str(item) for item in guidance_info.get("evidence", [])],
+        )
+        diff = float(guidance_reward) - float(rubric_reward)
+        rows.append(
+            {
+                "slug": record.get("slug", ""),
+                "split": record.get("split", ""),
+                "env": record.get("env", ""),
+                "task": record.get("task", ""),
+                "trial_dir": record.get("trial_dir", ""),
+                "rubric_reward": float(rubric_reward),
+                "guidance_reward": float(guidance_reward),
+                "signed_diff": round(diff, 4),
+                "abs_diff": round(abs(diff), 4),
+                "guidance_reasoning": guidance_info.get("reasoning", ""),
+                "guidance_evidence": guidance_info.get("evidence", []),
+                "guidance_exceeds_declared_score_ceiling": exceeds_declared_ceiling,
+                "near_declared_ceiling_with_foundational_failure": near_ceiling_with_foundational_failure,
+                "guidance_retry_count": retry_count,
+                "guidance_retried": retry_count > 0,
+                **usage_metrics,
+                **evidence,
+                **rubric_alignment,
+            }
+        )
+    return rows
+
+
+def threshold_agreement(rows: list[dict[str, Any]], threshold: float) -> float:
+    """Compute agreement of rubric/guidance pass labels at threshold."""
+    if not rows:
+        return 0.0
+    matches = sum((row["rubric_reward"] >= threshold) == (row["guidance_reward"] >= threshold) for row in rows)
+    return matches / len(rows)
+
+
+def summarize_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize joined rows for one split or all splits."""
+    if not rows:
+        return {"n": 0}
+    abs_diffs = [float(row["abs_diff"]) for row in rows]
+    signed_diffs = [float(row["signed_diff"]) for row in rows]
+    rubric = [float(row["rubric_reward"]) for row in rows]
+    guidance = [float(row["guidance_reward"]) for row in rows]
+    evidence_quality = [float(row["evidence_quality"]) for row in rows]
+    coverage = [float(row["guidance_vocab_coverage"]) for row in rows]
+    required_audit_coverage = [float(row["required_audit_coverage"]) for row in rows]
+    retry_counts = [float(row["guidance_retry_count"]) for row in rows]
+    llm_costs = [float(row["guidance_llm_cost_usd"]) for row in rows]
+    prompt_tokens = [float(row["guidance_prompt_tokens"]) for row in rows]
+    completion_tokens = [float(row["guidance_completion_tokens"]) for row in rows]
+    cache_read_tokens = [float(row["guidance_cache_read_tokens"]) for row in rows]
+    declared_ceiling_rows = [row for row in rows if row["declared_score_ceiling"] is not None]
+    action_required_rows = [row for row in rows if row["requires_action_or_side_effect_check"]]
+    output_location_required_rows = [row for row in rows if row["requires_output_location_conflict_check"]]
+    source_required_rows = [row for row in rows if row["requires_source_availability_check"]]
+    source_verification_required_rows = [row for row in rows if row["requires_source_verification_check"]]
+    return {
+        "n": len(rows),
+        "mae": round(mean(abs_diffs), 4),
+        "rmse": round(math.sqrt(mean([value * value for value in abs_diffs])), 4),
+        "bias": round(mean(signed_diffs), 4),
+        "pearson": round(pearson(rubric, guidance), 4) if pearson(rubric, guidance) is not None else None,
+        "spearman": round(pearson(ranks(rubric), ranks(guidance)), 4)
+        if pearson(ranks(rubric), ranks(guidance)) is not None
+        else None,
+        "threshold_agreement_0_5": round(threshold_agreement(rows, 0.5), 4),
+        "threshold_agreement_0_8": round(threshold_agreement(rows, 0.8), 4),
+        "mean_evidence_quality": round(mean(evidence_quality), 4),
+        "mean_required_audit_coverage": round(mean(required_audit_coverage), 4),
+        "mean_guidance_vocab_coverage": round(mean(coverage), 4),
+        "mean_guidance_retry_count": round(mean(retry_counts), 4),
+        "pct_guidance_retried": round(mean([1.0 if row["guidance_retried"] else 0.0 for row in rows]), 4),
+        "total_guidance_llm_cost_usd": round(sum(llm_costs), 4),
+        "mean_guidance_llm_cost_usd": round(mean(llm_costs), 4),
+        "total_guidance_prompt_tokens": int(sum(prompt_tokens)),
+        "mean_guidance_prompt_tokens": round(mean(prompt_tokens), 4),
+        "total_guidance_completion_tokens": int(sum(completion_tokens)),
+        "mean_guidance_completion_tokens": round(mean(completion_tokens), 4),
+        "total_guidance_cache_read_tokens": int(sum(cache_read_tokens)),
+        "mean_guidance_cache_read_tokens": round(mean(cache_read_tokens), 4),
+        "pct_has_file_or_path_evidence": round(
+            mean([1.0 if row["has_file_or_path_evidence"] else 0.0 for row in rows]), 4
+        ),
+        "pct_mentions_trajectory_or_tools": round(
+            mean([1.0 if row["mentions_trajectory_or_tools"] else 0.0 for row in rows]), 4
+        ),
+        "pct_mentions_score_calibration_cap_audit": round(
+            mean([1.0 if row["mentions_score_calibration_cap_audit"] else 0.0 for row in rows]), 4
+        ),
+        "pct_has_declared_score_ceiling": round(
+            mean([1.0 if row["declared_score_ceiling"] is not None else 0.0 for row in rows]), 4
+        ),
+        "pct_guidance_exceeds_declared_score_ceiling": round(
+            mean([1.0 if row["guidance_exceeds_declared_score_ceiling"] else 0.0 for row in rows]), 4
+        ),
+        "pct_near_declared_ceiling_with_foundational_failure": round(
+            mean([1.0 if row["near_declared_ceiling_with_foundational_failure"] else 0.0 for row in rows]), 4
+        ),
+        "pct_mentions_rubric_language": round(
+            mean([1.0 if row["mentions_rubric_language"] else 0.0 for row in rows]), 4
+        ),
+        "pct_mentions_source_guidance_conflict": round(
+            mean([1.0 if row["mentions_source_guidance_conflict"] else 0.0 for row in rows]), 4
+        ),
+        "pct_mentions_formula_cache_source_audit": round(
+            mean([1.0 if row["mentions_formula_cache_source_audit"] else 0.0 for row in rows]), 4
+        ),
+        "pct_potential_rubric_task_mismatch": round(
+            mean([1.0 if row["potential_rubric_task_mismatch"] else 0.0 for row in rows]), 4
+        ),
+        "pct_mentions_output_location_conflict_audit": round(
+            mean([1.0 if row["mentions_output_location_conflict_audit"] else 0.0 for row in rows]), 4
+        ),
+        "pct_mentions_action_side_effect_audit": round(
+            mean([1.0 if row["mentions_action_side_effect_audit"] else 0.0 for row in rows]), 4
+        ),
+        "pct_mentions_source_availability_audit": round(
+            mean([1.0 if row["mentions_source_availability_audit"] else 0.0 for row in rows]), 4
+        ),
+        "pct_mentions_source_verification_audit": round(
+            mean([1.0 if row["mentions_source_verification_audit"] else 0.0 for row in rows]), 4
+        ),
+        "pct_requires_action_or_side_effect_check": round(
+            mean([1.0 if row["requires_action_or_side_effect_check"] else 0.0 for row in rows]), 4
+        ),
+        "pct_requires_output_location_conflict_check": round(
+            mean([1.0 if row["requires_output_location_conflict_check"] else 0.0 for row in rows]), 4
+        ),
+        "pct_requires_source_availability_check": round(
+            mean([1.0 if row["requires_source_availability_check"] else 0.0 for row in rows]), 4
+        ),
+        "pct_requires_source_verification_check": round(
+            mean([1.0 if row["requires_source_verification_check"] else 0.0 for row in rows]), 4
+        ),
+        "pct_mentions_action_or_side_effects_when_required": round(
+            mean([1.0 if row["mentions_action_or_side_effects"] else 0.0 for row in action_required_rows]), 4
+        )
+        if action_required_rows
+        else 0.0,
+        "pct_mentions_action_side_effect_audit_when_required": round(
+            mean([1.0 if row["mentions_action_side_effect_audit"] else 0.0 for row in action_required_rows]), 4
+        )
+        if action_required_rows
+        else 0.0,
+        "pct_guidance_exceeds_declared_score_ceiling_when_declared": round(
+            mean([1.0 if row["guidance_exceeds_declared_score_ceiling"] else 0.0 for row in declared_ceiling_rows]),
+            4,
+        )
+        if declared_ceiling_rows
+        else 0.0,
+        "pct_mentions_output_location_conflict_audit_when_required": round(
+            mean(
+                [
+                    1.0 if row["mentions_output_location_conflict_audit"] else 0.0
+                    for row in output_location_required_rows
+                ]
+            ),
+            4,
+        )
+        if output_location_required_rows
+        else 0.0,
+        "pct_mentions_source_availability_audit_when_required": round(
+            mean([1.0 if row["mentions_source_availability_audit"] else 0.0 for row in source_required_rows]), 4
+        )
+        if source_required_rows
+        else 0.0,
+        "pct_mentions_source_verification_audit_when_required": round(
+            mean(
+                [1.0 if row["mentions_source_verification_audit"] else 0.0 for row in source_verification_required_rows]
+            ),
+            4,
+        )
+        if source_verification_required_rows
+        else 0.0,
+    }
+
+
+def summarize_guidance_runs(guidance_results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize all guidance run attempts, including failed runs without rewards."""
+    if not guidance_results:
+        return {"n": 0}
+    status_counts = Counter(str(result.get("status", "unknown") or "unknown") for result in guidance_results)
+    retry_counts = [float(guidance_retry_count(result)) for result in guidance_results]
+    usages = [guidance_usage_metrics(load_json(result.get("info_path", ""))) for result in guidance_results]
+    llm_costs = [float(usage["guidance_llm_cost_usd"]) for usage in usages]
+    prompt_tokens = [float(usage["guidance_prompt_tokens"]) for usage in usages]
+    completion_tokens = [float(usage["guidance_completion_tokens"]) for usage in usages]
+    cache_read_tokens = [float(usage["guidance_cache_read_tokens"]) for usage in usages]
+    missing_reward_count = sum(1 for result in guidance_results if result.get("reward") is None)
+    failed_count = status_counts.get("failed", 0)
+    ok_count = status_counts.get("ok", 0)
+    return {
+        "n": len(guidance_results),
+        "status_counts": dict(sorted(status_counts.items())),
+        "ok_count": ok_count,
+        "failed_count": failed_count,
+        "missing_reward_count": missing_reward_count,
+        "success_rate": round(ok_count / len(guidance_results), 4),
+        "failure_rate": round(failed_count / len(guidance_results), 4),
+        "mean_guidance_retry_count": round(mean(retry_counts), 4),
+        "pct_guidance_retried": round(mean([1.0 if count > 0 else 0.0 for count in retry_counts]), 4),
+        "total_guidance_llm_cost_usd": round(sum(llm_costs), 4),
+        "mean_guidance_llm_cost_usd": round(mean(llm_costs), 4),
+        "total_guidance_prompt_tokens": int(sum(prompt_tokens)),
+        "mean_guidance_prompt_tokens": round(mean(prompt_tokens), 4),
+        "total_guidance_completion_tokens": int(sum(completion_tokens)),
+        "mean_guidance_completion_tokens": round(mean(completion_tokens), 4),
+        "total_guidance_cache_read_tokens": int(sum(cache_read_tokens)),
+        "mean_guidance_cache_read_tokens": round(mean(cache_read_tokens), 4),
+    }
+
+
+def summarize(
+    rows: list[dict[str, Any]],
+    *,
+    guidance_results: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Summarize all rows and each split."""
+    by_split: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_split[str(row.get("split", ""))].append(row)
+    summary = {
+        "all": summarize_rows(rows),
+        "by_split": {split: summarize_rows(split_rows) for split, split_rows in sorted(by_split.items())},
+    }
+    if guidance_results is not None:
+        summary["guidance_runs"] = summarize_guidance_runs(guidance_results)
+    return summary
+
+
+def write_jsonl(rows: list[dict[str, Any]], path: Path) -> None:
+    """Write rows as JSON Lines."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row, sort_keys=True))
+            f.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze guidance scoring quality with guidance-grounded signals.")
+    parser.add_argument("--manifest", type=Path, default=Path("_run/rollouts_no_verifier_manifest_split.jsonl"))
+    parser.add_argument("--rubric-results", type=Path, default=Path("_run/gandalf_eval/results_rubric.jsonl"))
+    parser.add_argument("--guidance-results", type=Path, default=Path("_run/gandalf_eval/results_guidance.jsonl"))
+    parser.add_argument("--output-dir", type=Path, default=Path("_run/gandalf_eval/analysis"))
+    parser.add_argument("--top-n", type=int, default=10)
+    args = parser.parse_args()
+
+    guidance_results = load_jsonl(args.guidance_results)
+    rows = joined_rows(load_jsonl(args.manifest), load_jsonl(args.rubric_results), guidance_results)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    summary = summarize(rows, guidance_results=guidance_results)
+    (args.output_dir / "summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True))
+    write_jsonl(rows, args.output_dir / "joined_rows.jsonl")
+    top_disagreements = sorted(rows, key=lambda row: row["abs_diff"], reverse=True)[: args.top_n]
+    write_jsonl(top_disagreements, args.output_dir / "top_disagreements.jsonl")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    print(f"Wrote analysis to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/collect_harbor_rollouts.sh
+++ b/scripts/collect_harbor_rollouts.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TASK_ROOT="${TASK_ROOT:-$HOME/Downloads/harbor-research-v2-Batch1-2}"
+ENV_FILE="${ENV_FILE:-$HOME/Downloads/env}"
+OUT="${OUT:-_run/rollouts_no_verifier}"
+LOG_DIR="${LOG_DIR:-_run/rollout_logs}"
+MAX_JOBS="${MAX_JOBS:-5}"
+MODEL="${MODEL:-openai/gpt-5.5}"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Missing env file: $ENV_FILE" >&2
+  exit 1
+fi
+
+if ! command -v harbor >/dev/null 2>&1; then
+  echo "harbor CLI not found on PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT" "$LOG_DIR"
+
+set -a
+. "$ENV_FILE"
+set +a
+
+tasks=()
+while IFS= read -r task_dir; do
+  [ -f "$task_dir/task.toml" ] || continue
+  tasks+=("$task_dir")
+done < <(find "$TASK_ROOT" -mindepth 2 -maxdepth 2 -type d | sort)
+
+echo "Discovered ${#tasks[@]} Harbor task(s) under $TASK_ROOT"
+echo "Writing rollouts to $OUT and logs to $LOG_DIR"
+
+is_complete_slug() {
+  local slug="$1"
+  [ -n "$(find "$OUT/$slug" -path '*/agent/trajectory.json' ! -path '*/artifacts/*' -print -quit 2>/dev/null)" ]
+}
+
+slug_for_task_dir() {
+  local task_dir="$1"
+  local env_name
+  local task_name
+
+  env_name="$(basename "$(dirname "$task_dir")")"
+  task_name="$(basename "$task_dir")"
+  echo "${env_name}__${task_name}"
+}
+
+run_one() {
+  local task_dir="$1"
+  local env_name
+  local task_name
+  local slug
+  local out_dir
+  local log_file
+
+  env_name="$(basename "$(dirname "$task_dir")")"
+  task_name="$(basename "$task_dir")"
+  slug="${env_name}__${task_name}"
+  out_dir="$OUT/$slug"
+  log_file="$LOG_DIR/$slug.log"
+
+  if is_complete_slug "$slug"; then
+    echo "[$slug] skipped; canonical trajectory already exists"
+    return 0
+  fi
+
+  echo "[$slug] starting"
+  if harbor run \
+    -p "$task_dir" \
+    -a codex \
+    -m "$MODEL" \
+    -e docker \
+    -n 1 \
+    --disable-verification \
+    --artifact /home/agent/workspace \
+    --artifact /logs/agent \
+    --environment-build-timeout-multiplier 8 \
+    --agent-setup-timeout-multiplier 3 \
+    -o "$out_dir" \
+    --env-file "$ENV_FILE" \
+    --yes \
+    >"$log_file" 2>&1; then
+    echo "[$slug] complete"
+  else
+    echo "[$slug] failed; see $log_file" >&2
+    return 1
+  fi
+}
+
+status=0
+pids=()
+
+wait_for_slot() {
+  local pid
+  while [ "${#pids[@]}" -ge "$MAX_JOBS" ]; do
+    pid="${pids[0]}"
+    if ! wait "$pid"; then
+      status=1
+    fi
+    pids=("${pids[@]:1}")
+  done
+}
+
+wait_for_all() {
+  local pid
+  while [ "${#pids[@]}" -gt 0 ]; do
+    for pid in "${pids[@]}"; do
+      if ! wait "$pid"; then
+        status=1
+      fi
+    done
+    pids=()
+  done
+}
+
+for task_dir in "${tasks[@]}"; do
+  slug="$(slug_for_task_dir "$task_dir")"
+  if is_complete_slug "$slug"; then
+    echo "[$slug] skipped; canonical trajectory already exists"
+    continue
+  fi
+
+  run_one "$task_dir" &
+  pids+=("$!")
+  wait_for_slot
+done
+
+wait_for_all
+
+exit "$status"

--- a/scripts/dspy_optimize_guidance.py
+++ b/scripts/dspy_optimize_guidance.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Optimize guidance-scoring prompt variants with DSPy against rubric rewards.
+
+This is an eval/calibration helper only. Runtime Gandalf guidance mode still
+uses the reactive OpenHands judge that inspects the cloned workspace.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+try:
+    import dspy as _dspy
+except ImportError:
+    _dspy = None
+
+MIN_QUOTED_ENV_VALUE_LENGTH = 2
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load JSON Lines into a list of dictionaries."""
+    with path.open() as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def load_env_file(path: Path | None) -> None:
+    """Load simple KEY=VALUE lines into os.environ without printing values."""
+    if path is None or not path.exists():
+        return
+
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or key.startswith("#"):
+            continue
+        if len(value) >= MIN_QUOTED_ENV_VALUE_LENGTH and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        os.environ.setdefault(key, value)
+
+    if not os.environ.get("LLM_API_KEY"):
+        for provider_key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
+            if os.environ.get(provider_key):
+                os.environ["LLM_API_KEY"] = os.environ[provider_key]
+                break
+
+
+def load_final_output(trajectory_path: str) -> str:
+    """Extract the final agent message from an ATIF trajectory."""
+    try:
+        data = json.loads(Path(trajectory_path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return ""
+
+    final_output = ""
+    for step in reversed(data.get("steps", [])):
+        if step.get("source") == "agent" and not step.get("tool_calls"):
+            message = str(step.get("message", ""))
+            if message.strip():
+                final_output = message
+                break
+    return final_output
+
+
+def result_key(record: dict[str, Any]) -> tuple[str, str]:
+    """Stable key shared by manifest and eval result records."""
+    return str(record.get("slug", "")), str(record.get("trial_dir", ""))
+
+
+def build_examples_data(manifest: list[dict[str, Any]], rubric_results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Join manifest records to rubric rewards and load text inputs."""
+    rewards_by_key = {
+        result_key(result): float(result["reward"])
+        for result in rubric_results
+        if result.get("reward") is not None and result.get("status") == "ok"
+    }
+    examples: list[dict[str, Any]] = []
+    for record in manifest:
+        reward = rewards_by_key.get(result_key(record))
+        guidance_path = record.get("judge_guidance_path")
+        instructions_path = record.get("instruction_path")
+        if reward is None or not guidance_path or not instructions_path:
+            continue
+        try:
+            judge_guidance = Path(guidance_path).read_text()
+            instructions = Path(instructions_path).read_text()
+        except OSError:
+            continue
+        examples.append(
+            {
+                "instructions": instructions,
+                "judge_guidance": judge_guidance,
+                "final_output": load_final_output(str(record.get("trajectory_path", ""))),
+                "target_score": reward,
+                "split": record.get("split", ""),
+                "slug": record.get("slug", ""),
+                "trial_dir": record.get("trial_dir", ""),
+            }
+        )
+    return examples
+
+
+def load_dspy() -> Any:
+    """Import DSPy with a helpful error when the eval dependency group is missing."""
+    if _dspy is None:
+        msg = "DSPy is not installed. Run this script with `uv run --group eval` or install dspy-ai."
+        raise SystemExit(msg)
+    return _dspy
+
+
+def make_program(dspy: Any) -> Any:
+    """Construct a DSPy program for text-only guidance score calibration."""
+
+    class GuidanceScoreSignature(dspy.Signature):
+        """Predict a holistic score in [0, 1] from task text, final output, and grading guidance."""
+
+        task_instructions = dspy.InputField(desc="Original task instructions")
+        judge_guidance = dspy.InputField(desc="Free-form grading guidance")
+        final_output = dspy.InputField(desc="Final agent message extracted from the trajectory")
+        score = dspy.OutputField(desc="A number from 0 to 1 inclusive")
+
+    class GuidanceScoreProgram(dspy.Module):
+        def __init__(self) -> None:
+            self.predict = dspy.ChainOfThought(GuidanceScoreSignature)
+
+        def forward(self, instructions: str, judge_guidance: str, final_output: str) -> Any:
+            return self.predict(
+                task_instructions=instructions,
+                judge_guidance=judge_guidance,
+                final_output=final_output,
+            )
+
+    return GuidanceScoreProgram()
+
+
+def make_examples(dspy: Any, rows: list[dict[str, Any]]) -> list[Any]:
+    """Convert joined calibration rows into DSPy examples."""
+    examples = []
+    for row in rows:
+        example = dspy.Example(
+            instructions=row["instructions"],
+            judge_guidance=row["judge_guidance"],
+            final_output=row["final_output"],
+            target_score=row["target_score"],
+            split=row.get("split", ""),
+            slug=row.get("slug", ""),
+        ).with_inputs("instructions", "judge_guidance", "final_output")
+        examples.append(example)
+    return examples
+
+
+def score_metric(example: Any, pred: Any, _trace: Any = None) -> float:
+    """DSPy metric: one minus absolute score error, clipped to [0, 1]."""
+    try:
+        predicted = float(pred.score)
+        target = float(example.target_score)
+    except (AttributeError, TypeError, ValueError):
+        return 0.0
+    predicted = max(0.0, min(1.0, predicted))
+    return max(0.0, 1.0 - abs(predicted - target))
+
+
+def optimizer_class(dspy: Any, optimizer_name: str) -> Any:
+    """Pick an available DSPy optimizer class across DSPy versions."""
+    teleprompt = getattr(dspy, "teleprompt", None)
+    if optimizer_name == "mipro":
+        if hasattr(dspy, "MIPROv2"):
+            return dspy.MIPROv2
+        if teleprompt is not None and hasattr(teleprompt, "MIPROv2"):
+            return teleprompt.MIPROv2
+    if optimizer_name == "bootstrap":
+        if hasattr(dspy, "BootstrapFewShot"):
+            return dspy.BootstrapFewShot
+        if teleprompt is not None and hasattr(teleprompt, "BootstrapFewShot"):
+            return teleprompt.BootstrapFewShot
+    msg = f"Could not find DSPy optimizer {optimizer_name!r}."
+    raise SystemExit(msg)
+
+
+def compile_program(
+    dspy: Any,
+    program: Any,
+    trainset: list[Any],
+    *,
+    optimizer_name: str,
+    max_bootstrapped_demos: int,
+) -> Any:
+    """Compile a DSPy program with a version-tolerant optimizer call."""
+    if optimizer_name == "none":
+        return program
+
+    cls = optimizer_class(dspy, optimizer_name)
+    if optimizer_name == "mipro":
+        try:
+            optimizer = cls(metric=score_metric, auto="light")
+        except TypeError:
+            optimizer = cls(metric=score_metric)
+    else:
+        try:
+            optimizer = cls(metric=score_metric, max_bootstrapped_demos=max_bootstrapped_demos)
+        except TypeError:
+            optimizer = cls(metric=score_metric)
+
+    try:
+        return optimizer.compile(program, trainset=trainset)
+    except TypeError:
+        return optimizer.compile(program, trainset)
+
+
+def mean(values: list[float]) -> float:
+    """Return arithmetic mean, or 0 for empty input."""
+    return sum(values) / len(values) if values else 0.0
+
+
+def predict_score(program: Any, row: dict[str, Any]) -> float | None:
+    """Run a DSPy program and parse its score output."""
+    try:
+        pred = program(
+            instructions=row["instructions"],
+            judge_guidance=row["judge_guidance"],
+            final_output=row["final_output"],
+        )
+        score = float(pred.score)
+    except (AttributeError, TypeError, ValueError):
+        return None
+    return max(0.0, min(1.0, score))
+
+
+def summarize_predictions(program: Any, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize DSPy score predictions against rubric rewards."""
+    predictions: list[dict[str, Any]] = []
+    for row in rows:
+        pred = predict_score(program, row)
+        if pred is None:
+            predictions.append(
+                {
+                    "slug": row.get("slug", ""),
+                    "target": row["target_score"],
+                    "prediction": None,
+                    "abs_error": None,
+                }
+            )
+            continue
+        target = float(row["target_score"])
+        predictions.append(
+            {
+                "slug": row.get("slug", ""),
+                "target": target,
+                "prediction": round(pred, 4),
+                "abs_error": round(abs(pred - target), 4),
+            }
+        )
+
+    valid_errors = [float(item["abs_error"]) for item in predictions if item["abs_error"] is not None]
+    return {
+        "n": len(rows),
+        "n_valid": len(valid_errors),
+        "mae": round(mean(valid_errors), 4),
+        "predictions": predictions,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Optimize DSPy guidance scorer against rubric rewards.")
+    parser.add_argument("--manifest", type=Path, default=Path("_run/rollouts_no_verifier_manifest.jsonl"))
+    parser.add_argument("--rubric-results", type=Path, default=Path("_run/gandalf_eval/results_rubric.jsonl"))
+    parser.add_argument("--output", type=Path, default=Path("_run/dspy_guidance_optimized.json"))
+    parser.add_argument("--lm", default=os.environ.get("DSPY_MODEL", "openai/gpt-5.5"))
+    parser.add_argument("--env-file", type=Path, default=Path.home() / "Downloads" / "env")
+    parser.add_argument("--optimizer", choices=["none", "bootstrap", "mipro"], default="bootstrap")
+    parser.add_argument("--max-bootstrapped-demos", type=int, default=4)
+    parser.add_argument("--train-split", default="train")
+    parser.add_argument("--eval-split", default="eval")
+    parser.add_argument("--test-split", default="test")
+    parser.add_argument("--limit", type=int, default=None)
+    args = parser.parse_args()
+
+    load_env_file(args.env_file)
+    dspy = load_dspy()
+    dspy.configure(lm=dspy.LM(args.lm))
+
+    manifest = load_jsonl(args.manifest)
+    rubric_results = load_jsonl(args.rubric_results)
+    rows = build_examples_data(manifest, rubric_results)
+    if args.limit is not None:
+        rows = rows[: args.limit]
+    if not rows:
+        msg = "No calibration examples found."
+        raise SystemExit(msg)
+
+    train_rows = [row for row in rows if row.get("split") == args.train_split]
+    eval_rows = [row for row in rows if row.get("split") == args.eval_split]
+    test_rows = [row for row in rows if row.get("split") == args.test_split]
+    if not train_rows:
+        msg = f"No train examples found for split {args.train_split!r}."
+        raise SystemExit(msg)
+
+    examples = make_examples(dspy, train_rows)
+    program = make_program(dspy)
+    optimized = compile_program(
+        dspy,
+        program,
+        examples,
+        optimizer_name=args.optimizer,
+        max_bootstrapped_demos=args.max_bootstrapped_demos,
+    )
+
+    summary = {
+        "optimizer": args.optimizer,
+        "lm": args.lm,
+        "train_split": args.train_split,
+        "eval_split": args.eval_split,
+        "test_split": args.test_split,
+        "train": summarize_predictions(optimized, train_rows),
+        "eval": summarize_predictions(optimized, eval_rows),
+        "test": summarize_predictions(optimized, test_rows),
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if hasattr(optimized, "save"):
+        optimized.save(str(args.output))
+    else:
+        args.output.write_text(
+            json.dumps(
+                {
+                    "note": "Optimized DSPy program object did not expose save().",
+                    "examples": len(train_rows),
+                },
+                indent=2,
+            )
+        )
+    summary_path = args.output.with_suffix(".summary.json")
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True))
+
+    print(f"Optimized on {len(examples)} train example(s); wrote {args.output} and {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_guidance_scores.py
+++ b/scripts/eval_guidance_scores.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Run Gandalf rubric or guidance scoring over indexed Harbor rollout trials."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Literal, cast
+
+Mode = Literal["rubric", "guidance"]
+MIN_QUOTED_ENV_VALUE_LENGTH = 2
+DEFAULT_GEMINI_MODEL = "gemini/gemini-2.5-flash"
+DEFAULT_OPENAI_MODEL = "openai/gpt-5.5"
+DEFAULT_ANTHROPIC_MODEL = "anthropic/claude-haiku-4-5-20251001"
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load JSON Lines into a list of dictionaries."""
+    with path.open() as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def toml_str(value: str) -> str:
+    """Return a TOML string literal."""
+    return json.dumps(value)
+
+
+def load_env_file(path: Path) -> dict[str, str]:
+    """Load simple KEY=VALUE lines from an env file without printing values."""
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or key.startswith("#"):
+            continue
+        if len(value) >= MIN_QUOTED_ENV_VALUE_LENGTH and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def build_grader_env(env_file: Path | None) -> dict[str, str]:
+    """Build the environment used for Gandalf subprocesses."""
+    env = os.environ.copy()
+    if env_file is not None:
+        env.update(load_env_file(env_file))
+
+    return env
+
+
+def choose_default_model(env: dict[str, str]) -> str:
+    """Choose a default eval model that matches the available provider keys."""
+    if env.get("GANDALF_EVAL_MODEL"):
+        return env["GANDALF_EVAL_MODEL"]
+    if env.get("GOOGLE_API_KEY") or env.get("GEMINI_API_KEY"):
+        return DEFAULT_GEMINI_MODEL
+    if env.get("OPENAI_API_KEY"):
+        return DEFAULT_OPENAI_MODEL
+    if env.get("ANTHROPIC_API_KEY"):
+        return DEFAULT_ANTHROPIC_MODEL
+    return DEFAULT_GEMINI_MODEL
+
+
+def api_key_env_names_for_model(model: str) -> tuple[str, ...]:
+    """Return provider API key env vars suitable for a LiteLLM model string."""
+    normalized = model.lower()
+    if normalized.startswith(("gemini/", "google/")):
+        return ("GOOGLE_API_KEY", "GEMINI_API_KEY")
+    if normalized.startswith(("openai/", "gpt-")):
+        return ("OPENAI_API_KEY",)
+    if normalized.startswith(("anthropic/", "claude-")):
+        return ("ANTHROPIC_API_KEY",)
+    if normalized.startswith("openrouter/"):
+        return ("OPENROUTER_API_KEY",)
+    return ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY", "OPENROUTER_API_KEY")
+
+
+def set_llm_api_key_for_model(env: dict[str, str], model: str) -> None:
+    """Populate LLM_API_KEY from the provider key matching *model*, if needed."""
+    if env.get("LLM_API_KEY"):
+        return
+    for provider_key in api_key_env_names_for_model(model):
+        if env.get(provider_key):
+            env["LLM_API_KEY"] = env[provider_key]
+            return
+
+
+def validate_record(record: dict[str, Any], mode: Mode) -> list[str]:
+    """Return missing manifest fields required for the requested scoring mode."""
+    required = ["instruction_path", "trajectory_path", "workspace_path"]
+    if mode == "rubric":
+        required.append("rubric_path")
+    else:
+        required.append("judge_guidance_path")
+    return [field for field in required if not record.get(field)]
+
+
+def write_config(
+    record: dict[str, Any],
+    mode: Mode,
+    config_path: Path,
+    output_dir: Path,
+    *,
+    model: str,
+    judge_timeout: int,
+    judge_retries: int,
+) -> None:
+    """Write a Gandalf grader.toml for one collected trial."""
+    lines = [
+        f"model = {toml_str(model)}",
+        f"grading_mode = {toml_str(mode)}",
+        f"instructions_path = {toml_str(record['instruction_path'])}",
+        f"workdir = {toml_str(record['workspace_path'])}",
+        f"trajectory_path = {toml_str(record['trajectory_path'])}",
+        f"output_dir = {toml_str(str(output_dir))}",
+        f"judge_timeout = {judge_timeout}",
+        f"judge_retries = {judge_retries}",
+    ]
+    if mode == "rubric":
+        lines.append(f"rubric_path = {toml_str(record['rubric_path'])}")
+        if record.get("judge_guidance_path"):
+            lines.append(f"judge_guidance_path = {toml_str(record['judge_guidance_path'])}")
+    else:
+        lines.append(f"judge_guidance_path = {toml_str(record['judge_guidance_path'])}")
+
+    config_path.write_text("\n".join(lines) + "\n")
+
+
+def run_one(
+    record: dict[str, Any],
+    mode: Mode,
+    trial_eval_dir: Path,
+    *,
+    gandalf_cmd: list[str],
+    model: str,
+    judge_timeout: int,
+    judge_retries: int,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Run Gandalf for one manifest record and return a result summary."""
+    trial_eval_dir.mkdir(parents=True, exist_ok=True)
+    output_dir = trial_eval_dir / "grader"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    result: dict[str, Any] = {
+        "slug": record.get("slug", ""),
+        "env": record.get("env", ""),
+        "task": record.get("task", ""),
+        "split": record.get("split", ""),
+        "trial_dir": record.get("trial_dir", ""),
+        "mode": mode,
+        "eval_dir": str(trial_eval_dir),
+        "grader_output_dir": str(output_dir),
+        "gandalf_cmd": gandalf_cmd,
+    }
+
+    missing = validate_record(record, mode)
+    if missing:
+        result.update({"status": "skipped", "error": f"Missing required manifest fields: {', '.join(missing)}"})
+        return result
+
+    config_path = trial_eval_dir / "grader.toml"
+    write_config(
+        record,
+        mode,
+        config_path,
+        output_dir,
+        model=model,
+        judge_timeout=judge_timeout,
+        judge_retries=judge_retries,
+    )
+
+    proc = subprocess.run(
+        [*gandalf_cmd, "--config", str(config_path)],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+    (trial_eval_dir / "stdout.txt").write_text(proc.stdout)
+    (trial_eval_dir / "stderr.txt").write_text(proc.stderr)
+    result.update({"status": "ok" if proc.returncode == 0 else "failed", "returncode": proc.returncode})
+
+    reward_path = output_dir / "reward.json"
+    info_path = output_dir / "info.json"
+    if reward_path.exists():
+        result["reward"] = json.loads(reward_path.read_text()).get("reward")
+    if info_path.exists():
+        result["info_path"] = str(info_path)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Gandalf scoring over a Harbor rollout manifest.")
+    parser.add_argument("--manifest", type=Path, default=Path("_run/rollouts_no_verifier_manifest.jsonl"))
+    parser.add_argument("--mode", choices=["rubric", "guidance"], required=True)
+    parser.add_argument("--output-dir", type=Path, default=Path("_run/gandalf_eval"))
+    parser.add_argument(
+        "--gandalf-cmd",
+        default="uv run gandalf-the-grader",
+        help="Command used to invoke Gandalf, e.g. 'uv run gandalf-the-grader'.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help=(
+            "Judge model. Defaults to GANDALF_EVAL_MODEL, then a provider-compatible model from the loaded env file."
+        ),
+    )
+    parser.add_argument("--judge-timeout", type=int, default=300)
+    parser.add_argument("--judge-retries", type=int, default=1)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--split", choices=["train", "eval", "test"], default=None)
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=Path.home() / "Downloads" / "env",
+        help="Optional env file to load for Gandalf subprocesses. Values are not printed.",
+    )
+    parser.add_argument("--max-workers", type=int, default=1, help="Number of concurrent Gandalf subprocesses.")
+    args = parser.parse_args()
+
+    records = load_jsonl(args.manifest)
+    if args.split is not None:
+        records = [record for record in records if record.get("split") == args.split]
+    if args.limit is not None:
+        records = records[: args.limit]
+
+    mode = args.mode
+    gandalf_cmd = shlex.split(args.gandalf_cmd)
+    grader_env = build_grader_env(args.env_file)
+    model = args.model or choose_default_model(grader_env)
+    set_llm_api_key_for_model(grader_env, model)
+    results_path = args.output_dir / f"results_{mode}.jsonl"
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def run_indexed(index: int, record: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        slug = record.get("slug", f"trial_{index}")
+        trial_eval_dir = args.output_dir / mode / f"{index:03d}_{slug}"
+        result = run_one(
+            record,
+            cast("Mode", mode),
+            trial_eval_dir,
+            gandalf_cmd=gandalf_cmd,
+            model=model,
+            judge_timeout=args.judge_timeout,
+            judge_retries=args.judge_retries,
+            env=grader_env,
+        )
+        return index, result
+
+    indexed_records = list(enumerate(records))
+    results: list[dict[str, Any]] = []
+    with results_path.open("w") as f:
+        if args.max_workers <= 1:
+            for index, record in indexed_records:
+                _, result = run_indexed(index, record)
+                results.append(result)
+                f.write(json.dumps(result, sort_keys=True) + "\n")
+                f.flush()
+                print(f"[{len(results)}/{len(records)}] {record.get('slug', f'trial_{index}')}: {result['status']}")
+        else:
+            with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+                future_to_index = {
+                    executor.submit(run_indexed, index, record): index for index, record in indexed_records
+                }
+                for future in as_completed(future_to_index):
+                    index, result = future.result()
+                    results.append(result)
+                    f.write(json.dumps(result, sort_keys=True) + "\n")
+                    f.flush()
+                    print(
+                        f"[{len(results)}/{len(records)}] {records[index].get('slug', f'trial_{index}')}: {result['status']}"
+                    )
+
+    print(f"Wrote results to {results_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/index_harbor_rollouts.py
+++ b/scripts/index_harbor_rollouts.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Create a JSONL manifest for Harbor rollouts collected without verification."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def first_existing(candidates: list[Path]) -> Path | None:
+    """Return the first path that exists, or None."""
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def infer_slug(trajectory_path: Path, rollouts_root: Path) -> str:
+    """Infer the Harbor env/task slug from a trajectory path under rollouts_root."""
+    parts = trajectory_path.relative_to(rollouts_root).parts
+    for part in parts:
+        if "__" in part:
+            return part
+    return parts[0]
+
+
+def split_slug(slug: str) -> tuple[str, str]:
+    """Split a slug created by collect_harbor_rollouts.sh into env and task."""
+    if "__" not in slug:
+        return slug, ""
+    env, task = slug.split("__", 1)
+    return env, task
+
+
+def trial_dir_for_trajectory(trajectory_path: Path) -> Path:
+    """Return the Harbor trial directory for an agent/trajectory.json path."""
+    if trajectory_path.parent.name == "agent":
+        return trajectory_path.parent.parent
+    return trajectory_path.parent
+
+
+def is_canonical_trajectory(trajectory_path: Path, rollouts_root: Path) -> bool:
+    """Return whether trajectory_path is Harbor's canonical trial trajectory.
+
+    Harbor also captures requested artifacts under each trial's artifacts/
+    directory. When /logs/agent is collected, that artifact contains a copied
+    trajectory.json too. The manifest should index only the canonical
+    <trial>/agent/trajectory.json so each rollout trial appears once.
+    """
+    try:
+        parts = trajectory_path.relative_to(rollouts_root).parts
+    except ValueError:
+        return False
+    return trajectory_path.parent.name == "agent" and "artifacts" not in parts
+
+
+def workspace_path_for_trial(trial_dir: Path) -> Path | None:
+    """Find the captured workspace artifact path for a Harbor trial."""
+    return first_existing(
+        [
+            trial_dir / "artifacts" / "workspace",
+            trial_dir / "artifacts" / "home" / "agent" / "workspace",
+            trial_dir / "home" / "agent" / "workspace",
+            trial_dir / "workspace",
+        ]
+    )
+
+
+def task_metadata_paths(task_dir: Path) -> dict[str, str]:
+    """Resolve common Harbor task metadata file locations."""
+    instruction = first_existing([task_dir / "instruction.md", task_dir / "instructions.md", task_dir / "prompt.md"])
+    judge_guidance = first_existing([task_dir / "judge_guidance.md", task_dir / "tests" / "judge_guidance.md"])
+    rubric = first_existing([task_dir / "rubric.json", task_dir / "tests" / "rubric.json"])
+    return {
+        "instruction_path": str(instruction) if instruction else "",
+        "judge_guidance_path": str(judge_guidance) if judge_guidance else "",
+        "rubric_path": str(rubric) if rubric else "",
+    }
+
+
+def discover_rollout_records(rollouts_root: Path, tasks_root: Path) -> list[dict[str, Any]]:
+    """Discover rollout trials and map each trial to its Harbor task metadata."""
+    rollouts_root = rollouts_root.resolve()
+    tasks_root = tasks_root.resolve()
+    records: list[dict[str, Any]] = []
+
+    for trajectory_path in sorted(rollouts_root.rglob("agent/trajectory.json")):
+        if not is_canonical_trajectory(trajectory_path, rollouts_root):
+            continue
+        slug = infer_slug(trajectory_path, rollouts_root)
+        env, task = split_slug(slug)
+        task_dir = tasks_root / env / task if task else tasks_root / env
+        trial_dir = trial_dir_for_trajectory(trajectory_path)
+        workspace_path = workspace_path_for_trial(trial_dir)
+
+        record: dict[str, Any] = {
+            "slug": slug,
+            "env": env,
+            "task": task,
+            "task_dir": str(task_dir),
+            "trial_dir": str(trial_dir),
+            "trajectory_path": str(trajectory_path),
+            "workspace_path": str(workspace_path) if workspace_path else "",
+        }
+        record.update(task_metadata_paths(task_dir))
+        records.append(record)
+
+    return records
+
+
+def write_jsonl(records: list[dict[str, Any]], output_path: Path) -> None:
+    """Write records as JSON Lines."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w") as f:
+        for record in records:
+            f.write(json.dumps(record, sort_keys=True))
+            f.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Index Harbor rollout outputs for Gandalf grading.")
+    parser.add_argument(
+        "--rollouts-root",
+        type=Path,
+        default=Path("_run/rollouts_no_verifier"),
+        help="Root containing Harbor rollout outputs.",
+    )
+    parser.add_argument(
+        "--tasks-root",
+        type=Path,
+        default=Path.home() / "Downloads" / "harbor-research-v2-Batch1-2",
+        help="Root containing Harbor-format task directories.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("_run/rollouts_no_verifier_manifest.jsonl"),
+        help="Path to write the JSONL manifest.",
+    )
+    args = parser.parse_args()
+
+    records = discover_rollout_records(args.rollouts_root, args.tasks_root)
+    write_jsonl(records, args.output)
+    print(f"Wrote {len(records)} record(s) to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/split_harbor_manifest.py
+++ b/scripts/split_harbor_manifest.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Assign deterministic train/eval/test splits to an indexed Harbor rollout manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+DEFAULT_RATIOS = {"train": 0.6, "eval": 0.2, "test": 0.2}
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load JSON Lines into a list of dictionaries."""
+    with path.open() as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def stable_score(value: str, seed: str) -> int:
+    """Return a deterministic integer hash for split ordering."""
+    digest = hashlib.sha256(f"{seed}:{value}".encode()).hexdigest()
+    return int(digest, 16)
+
+
+def normalize_ratios(train: float, eval_ratio: float, test: float) -> dict[str, float]:
+    """Normalize split ratios and validate they are positive."""
+    ratios = {"train": train, "eval": eval_ratio, "test": test}
+    if any(value < 0 for value in ratios.values()):
+        msg = "Split ratios must be non-negative."
+        raise ValueError(msg)
+    total = sum(ratios.values())
+    if total <= 0:
+        msg = "At least one split ratio must be positive."
+        raise ValueError(msg)
+    return {key: value / total for key, value in ratios.items()}
+
+
+def split_counts(n_items: int, ratios: dict[str, float]) -> dict[str, int]:
+    """Return integer split counts that sum to n_items."""
+    raw = {key: n_items * ratio for key, ratio in ratios.items()}
+    counts = {key: int(value) for key, value in raw.items()}
+    remaining = n_items - sum(counts.values())
+    for key, _value in sorted(raw.items(), key=lambda item: item[1] - int(item[1]), reverse=True):
+        if remaining <= 0:
+            break
+        counts[key] += 1
+        remaining -= 1
+    return counts
+
+
+def assign_splits(
+    records: list[dict[str, Any]],
+    *,
+    seed: str = "gandalf-guidance-v1",
+    ratios: dict[str, float] | None = None,
+) -> list[dict[str, Any]]:
+    """Assign split labels, stratified by env and grouped by slug."""
+    ratios = ratios or DEFAULT_RATIOS
+
+    by_env: dict[str, dict[str, list[dict[str, Any]]]] = defaultdict(lambda: defaultdict(list))
+    for record in records:
+        env = str(record.get("env", ""))
+        slug = str(record.get("slug", ""))
+        by_env[env][slug].append(record)
+
+    split_by_slug: dict[str, str] = {}
+    for env, slug_map in by_env.items():
+        slugs = sorted(slug_map, key=lambda slug: stable_score(f"{env}:{slug}", seed))
+        counts = split_counts(len(slugs), ratios)
+        split_labels: list[str] = []
+        for label in ("train", "eval", "test"):
+            split_labels.extend([label] * counts[label])
+        split_by_slug.update(dict(zip(slugs, split_labels, strict=True)))
+
+    output: list[dict[str, Any]] = []
+    for record in records:
+        enriched = dict(record)
+        enriched["split"] = split_by_slug[str(record.get("slug", ""))]
+        enriched["split_seed"] = seed
+        enriched["split_group"] = "slug"
+        output.append(enriched)
+    return output
+
+
+def split_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize split counts overall and by environment."""
+    summary: dict[str, Any] = {"total": len(records), "splits": {}, "by_env": {}}
+    for record in records:
+        split = str(record.get("split", ""))
+        env = str(record.get("env", ""))
+        summary["splits"][split] = summary["splits"].get(split, 0) + 1
+        env_summary = summary["by_env"].setdefault(env, {})
+        env_summary[split] = env_summary.get(split, 0) + 1
+    return summary
+
+
+def write_jsonl(records: list[dict[str, Any]], output_path: Path) -> None:
+    """Write records as JSON Lines."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w") as f:
+        for record in records:
+            f.write(json.dumps(record, sort_keys=True))
+            f.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Assign train/eval/test splits to a Harbor rollout manifest.")
+    parser.add_argument("--input", type=Path, default=Path("_run/rollouts_no_verifier_manifest.jsonl"))
+    parser.add_argument("--output", type=Path, default=Path("_run/rollouts_no_verifier_manifest_split.jsonl"))
+    parser.add_argument("--seed", default="gandalf-guidance-v1")
+    parser.add_argument("--train", type=float, default=0.6)
+    parser.add_argument("--eval", dest="eval_ratio", type=float, default=0.2)
+    parser.add_argument("--test", type=float, default=0.2)
+    args = parser.parse_args()
+
+    ratios = normalize_ratios(args.train, args.eval_ratio, args.test)
+    records = assign_splits(load_jsonl(args.input), seed=args.seed, ratios=ratios)
+    write_jsonl(records, args.output)
+    print(json.dumps(split_summary(records), indent=2, sort_keys=True))
+    print(f"Wrote split manifest to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gandalf/guidance_evidence.py
+++ b/src/gandalf/guidance_evidence.py
@@ -1,0 +1,1008 @@
+"""String-level evidence helpers shared by guidance judging and analysis."""
+
+from __future__ import annotations
+
+import re
+
+ACTION_SIDE_EFFECT_AUDIT_MARKERS = (
+    "action/side-effect audit",
+    "action side-effect audit",
+)
+
+SCORE_CALIBRATION_AUDIT_MARKERS = (
+    "score calibration/cap audit",
+    "score calibration cap audit",
+    "cap audit",
+)
+SCORE_CALIBRATION_DECISION_PATTERNS = (
+    re.compile(r"\b(?:0(?:\.\d+)?|1(?:\.0+)?)\s*-\s*(?:0(?:\.\d+)?|1(?:\.0+)?)\b"),
+    re.compile(r"\b(?:band|ceiling|maximum|max score|maximum score|score allowed)\b"),
+    re.compile(r"\b(?:hard penalty|known failure mode|strictest|ceiling governs)\b"),
+    re.compile(r"\b(?:cap|caps|capped|capping)\b"),
+)
+WEAK_SCORE_CALIBRATION_NO_CAP_RE = re.compile(r"^\s*no\s+hard\s+caps?\s+(?:applies|apply)\s*\.?\s*$")
+SCORE_VALUE_RE = r"(?<![0-9.])(?:(?:0\.\d+|1\.0+)(?![0-9A-Za-z])|(?:0|1)(?![0-9A-Za-z.]))"
+SCORE_CALIBRATION_CEILING_PATTERNS = (
+    re.compile(rf"\bstrictest\s+applicable\s+cap\b[^.;\n]{{0,80}}({SCORE_VALUE_RE})"),
+    re.compile(
+        rf"\b(?:maximum score allowed|maximum allowed score|max score|score ceiling|strictest(?: practical)? ceiling)"
+        rf"\b[^.;\n]{{0,80}}({SCORE_VALUE_RE})"
+    ),
+    re.compile(rf"\bmaximum\b[^.;\n]{{0,80}}(?:{SCORE_VALUE_RE}\s*-\s*)?({SCORE_VALUE_RE})"),
+    re.compile(rf"({SCORE_VALUE_RE})\s+as\s+(?:the\s+)?maximum\b"),
+    re.compile(
+        rf"\b(?:cap|caps|capped|capping)\b[^.;\n]{{0,80}}\b(?:at|is|of|to|below|under|around)?\s*"
+        rf"(?:{SCORE_VALUE_RE}\s*-\s*)?({SCORE_VALUE_RE})"
+    ),
+)
+SCORE_CALIBRATION_NUMERIC_DECISION_RE = re.compile(rf"(?:{SCORE_VALUE_RE}\s*-\s*{SCORE_VALUE_RE}|{SCORE_VALUE_RE})")
+SCORE_CALIBRATION_CLAUSE_SPLIT_RE = re.compile(
+    r";|\n|\.(?=\s+[a-z])|,\s+(?=(?:and\s+)?(?:the\s+)?final score\b|no\s+(?:lower\s+)?hard\s+caps?\b)"
+)
+SCORE_CALIBRATION_NON_APPLIED_CAP_RE = re.compile(
+    r"\b(?:did not apply|do not apply|does not apply|not applied|not applying)\b"
+    r"|\bconsidered\s+caps?\s+for\b"
+    r"|\bno\s+(?:lower\s+)?hard\s+caps?\b[^.;\n]{0,60}\b(?:appl(?:y|ies|ied|icable)|explicit)\b"
+)
+SCORE_CALIBRATION_SELECTED_SCORE_BELOW_CAP_RE = re.compile(
+    r"\b(?:score|scoring|assigned|selected|chosen)?\b[^.;\n]{0,40}\b(?:below|under)\s+(?:that|the)\s+cap\b"
+)
+NEAR_DECLARED_CEILING_MARGIN = 0.05
+MIN_HIGH_FOUNDATIONAL_FAILURE_SCORE = 0.55
+MIN_NEAR_CEILING_FOUNDATIONAL_FAILURE_CEILING = 0.55
+MAX_HIGH_FOUNDATIONAL_FAILURE_CEILING = 0.75
+FOUNDATIONAL_FAILURE_RE = re.compile(
+    r"\bfoundational\b"
+    r"|\bcentral\s+(?:quantitative\s+)?(?:output|calculation|analysis|deliverable)\b[^.\n]{0,120}"
+    r"\b(?:wrong|incorrect|failed|missing|materially|unsupported)\b"
+    r"|\b(?:materially|foundationally)\s+(?:wrong|incorrect)\b"
+    r"|\bwrong\s+source\s+of\s+truth\b"
+    r"|\brequired\s+external\s+verification\b[^.\n]{0,120}\b(?:missing|missed|not\s+performed|failed)\b"
+    r"|\bmissed\s+a\s+required\s+external\s+verification\b"
+    r"|\b(?:did\s+not|does\s+not|failed\s+to|fails\s+to)\s+produce\b[^.\n]{0,120}"
+    r"\b(?:required\s+)?(?:deliverables?|artifacts?|outputs?|workbooks?|summar(?:y|ies))\b"
+    r"|\b(?:no|not\s+any)\s+(?:generated|agent-produced|required|separate|final)\b[^.\n]{0,120}"
+    r"\b(?:deliverables?|artifacts?|outputs?|workbooks?|summar(?:y|ies))\b"
+    r"|\bmissing\s+required\s+(?:deliverables?|artifacts?|outputs?|workbooks?|summar(?:y|ies))\b"
+    r"|\brequired\s+(?:deliverables?|artifacts?|outputs?|workbooks?|summar(?:y|ies))\b[^.\n]{0,80}"
+    r"\b(?:missing|absent|not\s+produced|not\s+present)\b",
+    re.IGNORECASE,
+)
+ABOVE_MIDPOINT_JUSTIFICATION_RE = re.compile(
+    r"\babove[-\s]midpoint justification\b"
+    r"|\babove\s+(?:the\s+)?midpoint\b[^\n]{0,160}\bbecause\b"
+    r"|\b(?:justify|justified|justifies|justifying)\b[^.\n]{0,120}"
+    r"\b(?:above[-\s]midpoint|higher placement|near(?:er)?\s+(?:the\s+)?(?:cap|ceiling)|upper)\b",
+    re.IGNORECASE,
+)
+SCORE_PLACEMENT_POSITIVE_JUSTIFICATION_RE = re.compile(
+    r"\b(?:score|scoring|selected|chosen|assigned|0\.\d+)\b[^.\n]{0,80}"
+    r"\b(?:appropriate|because|reflects)\b[^.\n]{0,160}"
+    r"\b(?:required artifacts?|required draft action|all four content sections|supporting facts|"
+    r"central requirements?|core requirements?|substantially correct|fully satisfied)\b",
+    re.IGNORECASE,
+)
+
+OUTPUT_LOCATION_CONFLICT_AUDIT_MARKERS = (
+    "output-location conflict audit",
+    "output location conflict audit",
+)
+OUTPUT_LOCATION_DETAIL_TERMS = (
+    "accessible",
+    "actual",
+    "artifact location",
+    "drafts",
+    "exposes",
+    "guidance",
+    "inaccessible",
+    "location penalty",
+    "mirrors",
+    "mounted",
+    "output-location penalty",
+    "penalize",
+    "penalty",
+    "required",
+    "task",
+    "trajectory",
+    "wrote",
+)
+
+SOURCE_AVAILABILITY_AUDIT_MARKERS = (
+    "source availability audit",
+    "source accessibility audit",
+)
+SOURCE_VERIFICATION_AUDIT_MARKERS = (
+    "source verification audit",
+    "independent source verification",
+    "independent source recomputation",
+)
+SOURCE_GUIDANCE_CONFLICT_AUDIT_MARKERS = (
+    "source/guidance conflict audit",
+    "source guidance conflict audit",
+)
+SOURCE_GUIDANCE_CONFLICT_RE = re.compile(
+    r"\bsource/guidance conflict audit\b"
+    r"|\bsource\s+and\s+guidance\s+conflicts?\b"
+    r"|\b(?:source|tracker|workbook|file|data|export|json|csv|xlsx|captured|matching|matches|matched)"
+    r"[^\n]{0,160}\b(?:but\s+)?not\s+the\s+guidance(?:'s)?\b"
+    r"|\b(?:source|tracker|workbook|file|data|export|json|csv|xlsx|captured|matching|matches|matched)"
+    r"[^\n]{0,160}\b(?:does|do|did)\s+not\s+meet\s+(?:the\s+)?guidance(?:'s)?\b"
+    r"|\b(?:source|tracker|workbook|file|data|export|json|csv|xlsx)\b[^\n]{0,160}"
+    r"\b(?:conflicts?|contradicts?|differs|does not match|not match|not the guidance|but not the guidance)\b"
+    r"[^\n]{0,160}\bguidance\b"
+    r"|\bguidance\b[^\n]{0,160}"
+    r"\b(?:conflicts?|contradicts?|differs|does not match|not match)\b"
+    r"[^\n]{0,160}\b(?:source|tracker|workbook|file|data|export|json|csv|xlsx)\b",
+    re.IGNORECASE,
+)
+SOURCE_GUIDANCE_AUTHORITY_RE = re.compile(
+    r"\b(?:authoritative|authority|source of truth|for scoring|scored against|grade[ds]? against|"
+    r"treated|treating|used|followed|accepts?|accepted|accepting|does not excuse|doesn't excuse|"
+    r"penalized|did not penalize)\b",
+    re.IGNORECASE,
+)
+SOURCE_GUIDANCE_NO_CONFLICT_RE = re.compile(
+    r"\bno\s+(?:substantive\s+)?(?:source/guidance\s+)?conflict\s+(?:was\s+)?found\b"
+    r"|\bno\s+(?:substantive\s+)?conflict\b[^.;\n]{0,160}\b(?:source|guidance)\b",
+    re.IGNORECASE,
+)
+
+WORKSPACE_ARTIFACT_EVIDENCE_MARKERS = (
+    "artifact",
+    "deliverable",
+    "final artifact",
+    "final state",
+    "output",
+    "workspace/artifact",
+)
+ORIGINAL_WORKSPACE_PATH_MARKERS = (
+    "/home/agent/workspace",
+    "/workspace",
+    "/workdir",
+    "/tmp/workdir",  # noqa: S108 - evidence marker, not a filesystem operation
+)
+CLONED_WORKSPACE_PATH_MARKERS = (
+    "/tmp/judge_workspace",  # noqa: S108 - evidence marker, not a filesystem operation
+    "cloned judge workspace",
+    "copied workspace",
+)
+INCONCLUSIVE_WORKSPACE_ARTIFACT_TERMS = (
+    "could not directly open",
+    "could not open",
+    "current judge filesystem",
+    "not present",
+)
+
+TRAJECTORY_EVIDENCE_MARKERS = (
+    "step ",
+    "tool call",
+    "trajectory",
+)
+TRAJECTORY_UNAVAILABLE_PATTERNS = (
+    re.compile(
+        r"\b(?:trajectory(?: file)?|gandalf_trajectory\.json)\b"
+        r"[^.;\n]{0,80}\b(?:could not (?:be )?(?:accessed|opened)|not accessible|not available|"
+        r"unavailable|not present|not found)\b"
+    ),
+    re.compile(
+        r"\b(?:could not (?:access|open)|not accessible|not available|unavailable|not present|not found)\b"
+        r"[^.;\n]{0,80}\b(?:trajectory(?: file)?|gandalf_trajectory\.json)\b"
+    ),
+)
+
+ABSOLUTE_PATH_RE = re.compile(r"/[A-Za-z0-9._~:@%+=,-]+(?:/[A-Za-z0-9._~:@%+=,-]+)*")
+OUTPUT_PATH_MARKERS = (
+    "deliverable",
+    "output",
+    "workdir",
+    "workspace",
+)
+
+ACTION_SIDE_EFFECT_TERMS = (
+    "calendar event",
+    "create calendar",
+    "draft email",
+    "email draft",
+    "external action",
+    "live action",
+    "outlook draft",
+    "publish",
+    "quickbooks update",
+    "send email",
+    "sent email",
+    "shopify update",
+    "square update",
+    "update quickbooks",
+    "update shopify",
+    "update square",
+)
+ACTION_SIDE_EFFECT_NON_REQUIREMENT_PATTERNS = (
+    re.compile(r"\bnot required\s*:\s*(?:.|\n)*?(?=\n\s*\n|$)"),
+    re.compile(r"\b(?:the\s+)?prompt does not ask for\b[^.\n]*(?:\.|$)"),
+    re.compile(r"\bno\b[^.\n]{0,180}\b(?:is|are)\s+required\b[^.\n]*(?:\.|$)"),
+    re.compile(r"\bdo not use\b[^.\n]{0,180}\b(?:as|for)\s+ground truth\b[^.\n]*(?:\.|$)"),
+    re.compile(r"\bshould not create or require\b[^.\n]*(?:\.|$)"),
+    re.compile(
+        r"\bcreat(?:e|ing|ed)\s+an?\s+outlook draft\b[^.\n]{0,160}\binstead of\b[^.\n]{0,160}"
+        r"(?:`?\.txt`?|\btxt\b|\btext file\b)[^.\n]*(?:\.|$)"
+    ),
+    re.compile(r"\b(?:management\s+)?email draft\b[^.\n]{0,120}(?:`?\.txt`?|\btxt\b|\btext file\b)"),
+    re.compile(r"\bdraft email\b[^.\n]{0,120}(?:`?\.txt`?|\btxt\b|\btext file\b)"),
+    re.compile(r"(?:`?\.txt`?|\btxt\b|\btext file\b)[^.\n]{0,120}\b(?:management\s+)?email draft\b[^.\n]*(?:\.|$)"),
+    re.compile(r"\bword summary and (?:management\s+)?email draft\b[^.\n]*(?:\.|\n|$)"),
+    re.compile(r"\bword document and (?:management\s+)?email draft\b[^.\n]*(?:\.|\n|$)"),
+    re.compile(r"\bword summary,\s+and\s+an?\s+(?:management\s+)?email draft\b[^.\n]*(?:\.|\n|$)"),
+    re.compile(r"\b(?:management\s+)?email draft checks\s*:"),
+)
+
+ACTION_SIDE_EFFECT_CONTEXT_TERMS = (
+    "artifact check",
+    "current artifact",
+    "current artifacts",
+    "draft artifact",
+    "final state",
+    "gandalf_trajectory",
+    "step ",
+    "steps ",
+    "trajectory",
+    "tool-call",
+    "tool-call query",
+    "tool call",
+    "tool calls",
+)
+ACTION_SIDE_EFFECT_DETAIL_TERMS = (
+    "called",
+    "created",
+    "drafted",
+    "found",
+    "isDraft",
+    "not a send",
+    "not sent",
+    "observed",
+    "only",
+    "returned",
+    "saved as a draft",
+    "searched",
+    "was used",
+    "was sent",
+)
+ACTION_SIDE_EFFECT_TRAJECTORY_CONTEXT_TERMS = (
+    "gandalf_trajectory",
+    "step ",
+    "steps ",
+    "trajectory",
+    "tool-call",
+    "tool-call query",
+    "tool call",
+    "tool calls",
+)
+
+ACTION_SIDE_EFFECT_SUBJECT_RE = (
+    r"(?:"
+    r"calendar events?"
+    r"|drafts?"
+    r"|emails?"
+    r"|external actions?"
+    r"|forbidden side effects?"
+    r"|live actions?"
+    r"|mutations?"
+    r"|publish"
+    r"|schedule"
+    r"|send"
+    r"|sent"
+    r"|side effects?"
+    r"|uploads?"
+    r"|updates?"
+    r")"
+)
+
+ACTION_SIDE_EFFECT_NO_RESULT_PATTERNS = (
+    re.compile(
+        rf"\bno\b[^.;\n]{{0,180}}\b{ACTION_SIDE_EFFECT_SUBJECT_RE}\b[^.;\n]{{0,180}}\b"
+        r"(?:found|observed|appears?|present|occurred)"
+    ),
+    re.compile(rf"\bno evidence of\b[^.;\n]{{0,180}}\b{ACTION_SIDE_EFFECT_SUBJECT_RE}\b"),
+)
+
+SOURCE_EXPECTATION_TERMS = (
+    "correct grounding",
+    "data source",
+    "data sources",
+    "expected source",
+    "expected sources",
+    "source data",
+    "source file",
+    "source files",
+    "source of truth",
+    "source-of-truth",
+    "source:",
+)
+
+SOURCE_CONNECTOR_NAMES = (
+    "airtable",
+    "faire",
+    "google calendar",
+    "gmail",
+    "outlook",
+    "quickbooks",
+    "salesforce",
+    "shopify",
+    "square",
+)
+
+SOURCE_CONTEXT_WORDS = (
+    "catalog",
+    "connector",
+    "connectors",
+    "context",
+    "customer",
+    "customers",
+    "data",
+    "database",
+    "databases",
+    "export",
+    "exports",
+    "file",
+    "files",
+    "history",
+    "invoice",
+    "invoices",
+    "ledger",
+    "order",
+    "orders",
+    "payment",
+    "payments",
+    "product",
+    "products",
+    "record",
+    "records",
+    "source",
+    "sources",
+)
+
+SOURCE_VERIFICATION_TERMS = (
+    "against source",
+    "accept within",
+    "check against source",
+    "check against the source",
+    "checked against source",
+    "checked against the source",
+    "independent verification",
+    "independently verify",
+    "recompute",
+    "recomputed",
+    "source records as source of truth",
+    "source records as the source of truth",
+    "source of truth for all exact figures",
+    "source of truth for exact figures",
+    "source-backed",
+    "tie out",
+    "tie-out",
+    "verification requirement",
+    "verify calculations",
+    "verify numerical",
+)
+
+SOURCE_AVAILABILITY_STATUS_TERMS = (
+    "accessible",
+    "available",
+    "contains",
+    "empty",
+    "exist",
+    "exists",
+    "missing",
+    "not accessible",
+    "not available",
+    "not present",
+    "present",
+    "unavailable",
+)
+
+SOURCE_AVAILABILITY_OBSERVATION_TERMS = (
+    "checked",
+    "confirmed",
+    "contains",
+    "found",
+    "inspected",
+    "listed",
+    "located",
+    "opened",
+    "read",
+    "searched",
+    "verified",
+    "included",
+    "are accessible",
+    "are present",
+    "is accessible",
+    "is present",
+    "was accessible",
+    "was available",
+    "was missing",
+    "was not accessible",
+    "was not available",
+    "was not present",
+    "was present",
+    "was unavailable",
+    "were accessible",
+    "were available",
+    "were missing",
+    "were not accessible",
+    "were not available",
+    "were not present",
+    "were present",
+    "were unavailable",
+)
+
+SOURCE_AVAILABILITY_SUBJECT_TERMS = (
+    "connector output",
+    "connector outputs",
+    "expected source",
+    "expected sources",
+    "order export",
+    "order exports",
+    "order-line export",
+    "order-line exports",
+    "source database",
+    "source databases",
+    "source directory",
+    "source directories",
+    "source export",
+    "source exports",
+    "source file",
+    "source files",
+    "sources",
+    "source workbook",
+    "source workbooks",
+    "tool-output",
+    "tool-outputs",
+)
+SOURCE_AVAILABILITY_FILE_RE = re.compile(
+    r"(?:"
+    r"/[A-Za-z0-9._~:@%+=,-]+(?:/[A-Za-z0-9._~:@%+=,-]+)*"
+    r"|\b[A-Za-z0-9._-]+\.(?:csv|json|xls|xlsx)\b"
+    r"|\b[A-Za-z][A-Za-z0-9]+(?:_[A-Za-z0-9]+){1,}\b"
+    r")"
+)
+SOURCE_AVAILABILITY_ACCESS_LABEL_RE = re.compile(
+    r"\b(?:"
+    r"source/trajectory check"
+    r"|source/trajectory-choice audit"
+    r"|source-choice audit"
+    r"|trajectory analytical command"
+    r"|trajectory check"
+    r"|trajectory/source check"
+    r"|trajectory/source-choice audit"
+    r")\b"
+)
+SOURCE_AVAILABILITY_ACCESS_ACTION_TERMS = (
+    "displayed",
+    "explored",
+    "exported",
+    "extracted",
+    "inspected",
+    "loaded",
+    "opened",
+    "parsed",
+    "queried",
+    "read",
+    "used",
+    "viewed",
+)
+
+SOURCE_AVAILABILITY_CONNECTOR_CONTEXT_TERMS = (
+    "data",
+    "directory",
+    "directories",
+    "export",
+    "exports",
+    "file",
+    "files",
+    "order",
+    "orders",
+    "source",
+    "sources",
+    "tool-output",
+    "tool-outputs",
+)
+
+SOURCE_AVAILABILITY_NO_RESULT_SUBJECT_RE = (
+    r"(?:"
+    r"source(?:s| files?| directories?| exports?)?"
+    r"|tool-outputs?"
+    r"|connector outputs?"
+    r"|order-line exports?"
+    r"|(?:[a-z0-9_-]+/)+[a-z0-9_-]+\.(?:csv|xlsx|json)"
+    r"|orders?\.(?:csv|xlsx|json)"
+    r"|[a-z0-9_-]+\.(?:csv|xlsx|json)"
+    r")"
+)
+SOURCE_AVAILABILITY_NO_RESULT_PATTERNS = (
+    re.compile(
+        rf"\b(?:listed|searched|returned|showed|displayed|found|rg --files|find command)\b"
+        rf"[^;\n]{{0,240}}\bno\b(?!\s+references?\s+to\b)[^;\n]{{0,180}}\b"
+        rf"{SOURCE_AVAILABILITY_NO_RESULT_SUBJECT_RE}\b"
+    ),
+    re.compile(
+        rf"\b(?:listed|searched|returned|showed|displayed|found|rg --files|find command)\b"
+        rf"[^.;\n]{{0,180}}\bno\b(?!\s+references?\s+to\b)[^.;\n]{{0,180}}\b"
+        rf"{SOURCE_AVAILABILITY_NO_RESULT_SUBJECT_RE}\b"
+    ),
+    re.compile(
+        rf"\bno\b(?!\s+references?\s+to\b)[^.;\n]{{0,180}}\b"
+        rf"{SOURCE_AVAILABILITY_NO_RESULT_SUBJECT_RE}\b[^.;\n]{{0,120}}\b"
+        r"(?:found|returned|listed|present|visible|appeared)\b"
+    ),
+)
+SOURCE_AVAILABILITY_INVERTED_STATUS_RE = re.compile(
+    r"\b(?:accessible|available|present)\b[^.;\n]{0,180}\b(?:was|were)\b"
+)
+
+SOURCE_VERIFICATION_ACTION_TERMS = (
+    "independently verified",
+    "recalculated",
+    "recomputed",
+    "verified against",
+)
+
+SOURCE_VERIFICATION_CHECK_LABEL_RE = re.compile(
+    r"\b(?:"
+    r"financial source check"
+    r"|independently checked (?:available )?source csvs? with python"
+    r"|independent (?:shopify|quickbooks|faire|square|source) verification"
+    r"|independent source calculation"
+    r"|independent source check"
+    r"|source calculation"
+    r"|source check with python"
+    r"|source/trajectory check"
+    r"|source verification script output"
+    r"|trajectory/source check"
+    r"|csv verification"
+    r"|raw finance-source xml check"
+    r")\b"
+)
+SOURCE_VERIFICATION_FILE_RE = re.compile(
+    r"(?:"
+    r"/[A-Za-z0-9._~:@%+=,-]+/[A-Za-z0-9._~:@%+=,-]+(?:/[A-Za-z0-9._~:@%+=,-]+)*"
+    r"|\b[A-Za-z0-9._-]+\.(?:csv|json|xls|xlsx)\b"
+    r"|\b(?:csvs?|json files?|xlsx files?|xls files?)\b"
+    r"|\bsource\s+json\b"
+    r"|\braw(?:\s+[a-z0-9/&-]+){0,8}\s+json\b"
+    r"|\braw xlsx xml\b"
+    r"|\b(?:bronze|silver|golden) deliverable\b"
+    r"|\bsource cells?\b"
+    r"|\bsource-of-truth checkpoints?\b"
+    r")"
+)
+SOURCE_VERIFICATION_SCRIPT_RE = re.compile(r"\b[A-Za-z0-9._-]+\.py\b")
+SOURCE_VERIFICATION_SCRIPT_SOURCE_TERMS = (
+    "budget source",
+    "cogs tracker",
+    "golden deliverable",
+    "margin tracker",
+    "source data",
+    "source figures",
+    "source records",
+    "source rows",
+    "source totals",
+    "source workbook",
+    "source workbooks",
+)
+SOURCE_VERIFICATION_RESULT_RE = re.compile(
+    r"(?:"
+    r"\$[0-9]"
+    r"|\b[0-9][0-9,.]*\b"
+    r"|\b(?:calculated|computed|confirmed|contain|contains|extracted|gives|matched|produced|returned|showed)\b"
+    r")"
+)
+
+
+def has_evidence_term(text: str, term: str) -> bool:
+    """Return whether text includes a term as a word or exact phrase."""
+    return bool(re.search(rf"(?<![a-z0-9]){re.escape(term)}(?![a-z0-9])", text))
+
+
+def has_any_evidence_term(text: str, terms: tuple[str, ...]) -> bool:
+    """Return whether text includes any evidence term as a word or phrase."""
+    return any(has_evidence_term(text, term) for term in terms)
+
+
+def has_source_availability_subject(text: str) -> bool:
+    """Return whether text names likely source material rather than generic prose."""
+    if has_any_evidence_term(text, SOURCE_AVAILABILITY_SUBJECT_TERMS):
+        return True
+    return has_any_evidence_term(text, SOURCE_CONNECTOR_NAMES) and has_any_evidence_term(
+        text,
+        SOURCE_AVAILABILITY_CONNECTOR_CONTEXT_TERMS,
+    )
+
+
+def has_source_availability_no_result(text: str) -> bool:
+    """Return whether text reports an observed absence of named source material."""
+    return any(pattern.search(text) for pattern in SOURCE_AVAILABILITY_NO_RESULT_PATTERNS)
+
+
+def has_source_availability_status_observation(text: str) -> bool:
+    """Return whether one clause reports an observed source availability status."""
+    for clause in re.split(r"[.;\n]", text):
+        if (
+            has_source_availability_subject(clause)
+            and has_any_evidence_term(clause, SOURCE_AVAILABILITY_STATUS_TERMS)
+            and has_any_evidence_term(clause, SOURCE_AVAILABILITY_OBSERVATION_TERMS)
+        ):
+            return True
+    return False
+
+
+def has_source_availability_detail(text: str) -> bool:
+    """Return whether evidence reports a concrete source availability status."""
+    if has_source_availability_no_result(text) or has_source_availability_status_observation(text):
+        return True
+    if SOURCE_AVAILABILITY_INVERTED_STATUS_RE.search(text) and (
+        has_source_availability_subject(text)
+        or has_any_evidence_term(text, SOURCE_CONNECTOR_NAMES)
+        or bool(SOURCE_AVAILABILITY_FILE_RE.search(text))
+    ):
+        return True
+    if (
+        has_any_evidence_term(text, SOURCE_AVAILABILITY_STATUS_TERMS)
+        and has_any_evidence_term(text, SOURCE_AVAILABILITY_OBSERVATION_TERMS)
+        and (
+            has_source_availability_subject(text)
+            or has_any_evidence_term(text, SOURCE_CONNECTOR_NAMES)
+            or bool(SOURCE_AVAILABILITY_FILE_RE.search(text))
+        )
+    ):
+        return True
+    for clause in re.split(r"[.;\n]", text):
+        if not (
+            has_any_evidence_term(clause, SOURCE_AVAILABILITY_STATUS_TERMS)
+            and has_any_evidence_term(clause, SOURCE_AVAILABILITY_OBSERVATION_TERMS)
+        ):
+            continue
+        if (
+            has_source_availability_subject(clause)
+            or has_any_evidence_term(clause, SOURCE_CONNECTOR_NAMES)
+            or bool(SOURCE_AVAILABILITY_FILE_RE.search(clause))
+        ):
+            return True
+    return False
+
+
+def has_source_access_observation(text: str) -> bool:
+    """Return whether evidence proves source access through retrieval or verification."""
+    if (
+        any(marker in text for marker in SOURCE_VERIFICATION_AUDIT_MARKERS) and has_source_verification_detail(text)
+    ) or has_source_verification_observation(text):
+        return True
+    if not SOURCE_AVAILABILITY_ACCESS_LABEL_RE.search(text):
+        return False
+    if not has_any_evidence_term(text, SOURCE_AVAILABILITY_ACCESS_ACTION_TERMS):
+        return False
+    return (
+        has_source_availability_subject(text)
+        or has_any_evidence_term(text, SOURCE_CONNECTOR_NAMES)
+        or bool(SOURCE_AVAILABILITY_FILE_RE.search(text))
+    )
+
+
+def has_source_verification_observation(text: str) -> bool:
+    """Return whether text reports a concrete source-backed verification result."""
+    return (
+        bool(SOURCE_VERIFICATION_CHECK_LABEL_RE.search(text))
+        and bool(SOURCE_VERIFICATION_FILE_RE.search(text))
+        and bool(SOURCE_VERIFICATION_RESULT_RE.search(text))
+    )
+
+
+def has_source_verification_detail(text: str) -> bool:
+    """Return whether source-verification evidence names source material plus a check/result."""
+    names_source_material = bool(SOURCE_VERIFICATION_FILE_RE.search(text)) or (
+        bool(SOURCE_VERIFICATION_SCRIPT_RE.search(text))
+        and has_any_evidence_term(text, SOURCE_VERIFICATION_SCRIPT_SOURCE_TERMS)
+    )
+    return names_source_material and (
+        any(term in text for term in SOURCE_VERIFICATION_ACTION_TERMS)
+        or bool(SOURCE_VERIFICATION_RESULT_RE.search(text))
+    )
+
+
+def has_source_guidance_conflict_language(text: str) -> bool:
+    """Return whether text reports a conflict between accessible source evidence and guidance."""
+    return bool(SOURCE_GUIDANCE_CONFLICT_RE.search(text))
+
+
+def has_source_guidance_conflict_audit(evidence: list[str]) -> bool:
+    """Return whether evidence labels and reconciles a source/guidance conflict."""
+    for item in evidence:
+        lowered = item.lower()
+        has_marker = any(marker in lowered for marker in SOURCE_GUIDANCE_CONFLICT_AUDIT_MARKERS)
+        if (
+            has_marker
+            and SOURCE_GUIDANCE_NO_CONFLICT_RE.search(lowered)
+            and "source" in lowered
+            and "guidance" in lowered
+        ):
+            return True
+        if (
+            has_marker
+            and has_source_guidance_conflict_language(lowered)
+            and SOURCE_GUIDANCE_AUTHORITY_RE.search(lowered)
+        ):
+            return True
+    return False
+
+
+def has_action_side_effect_observation(text: str) -> bool:
+    """Return whether text reports an observed action or side-effect check."""
+    if not has_any_evidence_term(text, ACTION_SIDE_EFFECT_CONTEXT_TERMS):
+        return False
+    return any(pattern.search(text) for pattern in ACTION_SIDE_EFFECT_NO_RESULT_PATTERNS)
+
+
+def has_action_side_effect_detail(text: str) -> bool:
+    """Return whether evidence reports a concrete action or side-effect check."""
+    if has_action_side_effect_observation(text):
+        return True
+    if not has_any_evidence_term(text, ACTION_SIDE_EFFECT_CONTEXT_TERMS):
+        return False
+    return has_any_evidence_term(text, ACTION_SIDE_EFFECT_DETAIL_TERMS) and bool(
+        re.search(ACTION_SIDE_EFFECT_SUBJECT_RE, text)
+    )
+
+
+def has_unlabeled_action_side_effect_detail(text: str) -> bool:
+    """Return whether unlabeled evidence concretely checks trajectory action state."""
+    return has_any_evidence_term(text, ACTION_SIDE_EFFECT_TRAJECTORY_CONTEXT_TERMS) and has_action_side_effect_detail(
+        text
+    )
+
+
+def requires_action_side_effect_audit(instructions: str, judge_guidance: str) -> bool:
+    """Return whether task/guidance text calls for external-action auditing."""
+    combined = f"{instructions}\n{judge_guidance}".lower()
+    for pattern in ACTION_SIDE_EFFECT_NON_REQUIREMENT_PATTERNS:
+        combined = pattern.sub("\n", combined)
+    return any(term in combined for term in ACTION_SIDE_EFFECT_TERMS)
+
+
+def requires_source_availability_audit(instructions: str, judge_guidance: str) -> bool:
+    """Return whether task/guidance names expected source material to audit."""
+    combined = f"{instructions}\n{judge_guidance}".lower()
+    if any(term in combined for term in SOURCE_EXPECTATION_TERMS):
+        return True
+
+    context_pattern = "|".join(re.escape(word) for word in SOURCE_CONTEXT_WORDS)
+    for connector in SOURCE_CONNECTOR_NAMES:
+        connector_pattern = re.escape(connector)
+        if re.search(rf"\b{connector_pattern}\b[^.\n]{{0,120}}\b({context_pattern})\b", combined):
+            return True
+        if re.search(rf"\b({context_pattern})\b[^.\n]{{0,120}}\b{connector_pattern}\b", combined):
+            return True
+
+    return False
+
+
+def requires_source_verification_audit(instructions: str, judge_guidance: str) -> bool:
+    """Return whether task/guidance calls for independent source verification."""
+    combined = f"{instructions}\n{judge_guidance}".lower()
+    return any(term in combined for term in SOURCE_VERIFICATION_TERMS)
+
+
+def extract_absolute_paths(text: str) -> set[str]:
+    """Extract normalized absolute paths from free-form task/guidance text."""
+    return {match.group(0).rstrip(".,;:)']\"`") for match in ABSOLUTE_PATH_RE.finditer(text)}
+
+
+def extract_output_location_paths(text: str) -> set[str]:
+    """Extract absolute paths that look like output, artifact, or workspace locations."""
+    output_paths: set[str] = set()
+    for path in extract_absolute_paths(text):
+        lowered = path.lower()
+        if any(marker in lowered for marker in OUTPUT_PATH_MARKERS):
+            output_paths.add(path.rstrip("/"))
+    return output_paths
+
+
+def paths_are_compatible(left: str, right: str) -> bool:
+    """Return whether two output paths are the same location or one contains the other."""
+    left_norm = left.rstrip("/")
+    right_norm = right.rstrip("/")
+    return left_norm == right_norm or left_norm.startswith(f"{right_norm}/") or right_norm.startswith(f"{left_norm}/")
+
+
+def requires_output_location_conflict_audit(instructions: str, judge_guidance: str) -> bool:
+    """Return whether task instructions and guidance name conflicting output locations."""
+    instruction_paths = extract_output_location_paths(instructions)
+    guidance_paths = extract_output_location_paths(judge_guidance)
+    if not instruction_paths or not guidance_paths:
+        return False
+    return any(
+        not any(paths_are_compatible(instruction_path, guidance_path) for instruction_path in instruction_paths)
+        for guidance_path in guidance_paths
+    )
+
+
+def has_action_side_effect_audit(evidence: list[str]) -> bool:
+    """Return whether evidence includes the required named action audit item."""
+    for item in evidence:
+        lowered = item.lower()
+        if any(marker in lowered for marker in ACTION_SIDE_EFFECT_AUDIT_MARKERS) and has_action_side_effect_detail(
+            lowered
+        ):
+            return True
+        if has_action_side_effect_observation(lowered):
+            return True
+        if has_unlabeled_action_side_effect_detail(lowered):
+            return True
+    return False
+
+
+def has_output_location_conflict_audit(evidence: list[str]) -> bool:
+    """Return whether evidence includes the required output-location conflict audit item."""
+    for item in evidence:
+        lowered = item.lower()
+        if any(marker in lowered for marker in OUTPUT_LOCATION_CONFLICT_AUDIT_MARKERS) and (
+            bool(extract_absolute_paths(lowered)) or has_any_evidence_term(lowered, OUTPUT_LOCATION_DETAIL_TERMS)
+        ):
+            return True
+    return False
+
+
+def has_source_availability_audit(evidence: list[str]) -> bool:
+    """Return whether evidence includes the required source availability audit item."""
+    for item in evidence:
+        lowered = item.lower()
+        if any(marker in lowered for marker in SOURCE_AVAILABILITY_AUDIT_MARKERS) and has_source_availability_detail(
+            lowered
+        ):
+            return True
+    return False
+
+
+def has_source_verification_audit(evidence: list[str]) -> bool:
+    """Return whether evidence includes the required source verification audit item."""
+    for item in evidence:
+        lowered = item.lower()
+        if any(marker in lowered for marker in SOURCE_VERIFICATION_AUDIT_MARKERS) and has_source_verification_detail(
+            lowered
+        ):
+            return True
+        if has_source_verification_observation(lowered):
+            return True
+    return False
+
+
+def strip_score_calibration_markers(text: str) -> str:
+    """Remove score-calibration marker text before checking for substantive decisions."""
+    for marker in SCORE_CALIBRATION_AUDIT_MARKERS:
+        text = text.replace(marker, "")
+    return text.strip(" \t\n\r:-.")
+
+
+def has_score_calibration_decision(text: str) -> bool:
+    """Return whether score-calibration evidence names a band, cap, or ceiling decision."""
+    markerless = strip_score_calibration_markers(text)
+    if WEAK_SCORE_CALIBRATION_NO_CAP_RE.fullmatch(markerless):
+        return False
+    return (
+        bool(SCORE_CALIBRATION_NUMERIC_DECISION_RE.search(markerless))
+        and any(pattern.search(markerless) for pattern in SCORE_CALIBRATION_DECISION_PATTERNS)
+        and bool(score_calibration_ceiling_values(markerless))
+    )
+
+
+def score_calibration_ceiling_values(text: str) -> list[float]:
+    """Return numeric ceiling values from score-calibration text."""
+    ceilings: list[float] = []
+    markerless = strip_score_calibration_markers(text)
+    for clause in SCORE_CALIBRATION_CLAUSE_SPLIT_RE.split(markerless):
+        if SCORE_CALIBRATION_NON_APPLIED_CAP_RE.search(clause):
+            continue
+        if SCORE_CALIBRATION_SELECTED_SCORE_BELOW_CAP_RE.search(clause):
+            continue
+        for pattern in SCORE_CALIBRATION_CEILING_PATTERNS:
+            ceilings.extend(float(match.group(1)) for match in pattern.finditer(clause))
+    return ceilings
+
+
+def extract_score_calibration_ceiling(evidence: list[str]) -> float | None:
+    """Extract the strictest numeric score ceiling declared by calibration evidence."""
+    ceilings: list[float] = []
+    for item in evidence:
+        lowered = item.lower()
+        if not any(marker in lowered for marker in SCORE_CALIBRATION_AUDIT_MARKERS):
+            continue
+        ceilings.extend(score_calibration_ceiling_values(lowered))
+    return min(ceilings) if ceilings else None
+
+
+def has_score_calibration_audit(evidence: list[str]) -> bool:
+    """Return whether evidence includes the required score calibration/cap audit item."""
+    for item in evidence:
+        lowered = item.lower()
+        if any(marker in lowered for marker in SCORE_CALIBRATION_AUDIT_MARKERS) and has_score_calibration_decision(
+            lowered
+        ):
+            return True
+    return False
+
+
+def has_score_calibration_audit_marker(evidence: list[str]) -> bool:
+    """Return whether evidence includes a score-calibration audit label."""
+    return any(any(marker in item.lower() for marker in SCORE_CALIBRATION_AUDIT_MARKERS) for item in evidence)
+
+
+def has_foundational_failure_language(text: str) -> bool:
+    """Return whether text describes foundational, central, or required-verification failures."""
+    return bool(FOUNDATIONAL_FAILURE_RE.search(text))
+
+
+def has_above_midpoint_justification(evidence: list[str]) -> bool:
+    """Return whether score-calibration evidence explicitly justifies above-midpoint placement."""
+    for item in evidence:
+        lowered = item.lower()
+        if not any(marker in lowered for marker in SCORE_CALIBRATION_AUDIT_MARKERS):
+            continue
+        if ABOVE_MIDPOINT_JUSTIFICATION_RE.search(item) or SCORE_PLACEMENT_POSITIVE_JUSTIFICATION_RE.search(item):
+            return True
+    return False
+
+
+def requires_above_midpoint_justification(
+    score: float,
+    score_ceiling: float | None,
+    *,
+    reasoning: str,
+    evidence: list[str],
+) -> bool:
+    """Return whether a high score with foundational failures needs explicit justification."""
+    if score_ceiling is None:
+        return False
+    if score_ceiling < MIN_NEAR_CEILING_FOUNDATIONAL_FAILURE_CEILING:
+        return False
+    near_declared_ceiling = score >= score_ceiling - NEAR_DECLARED_CEILING_MARGIN
+    high_foundational_failure_score = (
+        score_ceiling <= MAX_HIGH_FOUNDATIONAL_FAILURE_CEILING and score >= MIN_HIGH_FOUNDATIONAL_FAILURE_SCORE
+    )
+    if not near_declared_ceiling and not high_foundational_failure_score:
+        return False
+    combined = " ".join([reasoning, *evidence])
+    return has_foundational_failure_language(combined) and not has_above_midpoint_justification(evidence)
+
+
+def has_workspace_artifact_evidence(evidence: list[str]) -> bool:
+    """Return whether evidence includes a workspace, artifact, or final-state check."""
+    for item in evidence:
+        lowered = item.lower()
+        if any(marker in lowered for marker in OUTPUT_LOCATION_CONFLICT_AUDIT_MARKERS):
+            continue
+        if (
+            has_any_evidence_term(lowered, INCONCLUSIVE_WORKSPACE_ARTIFACT_TERMS)
+            and any(marker in lowered for marker in ORIGINAL_WORKSPACE_PATH_MARKERS)
+            and not any(marker in lowered for marker in CLONED_WORKSPACE_PATH_MARKERS)
+        ):
+            continue
+        if any(marker in lowered for marker in WORKSPACE_ARTIFACT_EVIDENCE_MARKERS):
+            return True
+        if any(
+            any(marker in path.lower() for marker in ("deliverable", "output", "workdir"))
+            for path in extract_absolute_paths(item)
+        ):
+            return True
+    return False
+
+
+def has_unavailable_trajectory_claim(text: str) -> bool:
+    """Return whether text says the trajectory itself was unavailable."""
+    return any(pattern.search(text) for pattern in TRAJECTORY_UNAVAILABLE_PATTERNS)
+
+
+def has_trajectory_evidence(evidence: list[str]) -> bool:
+    """Return whether evidence includes a trajectory, step, or tool-call check."""
+    for item in evidence:
+        lowered = item.lower()
+        if has_unavailable_trajectory_claim(lowered):
+            continue
+        if any(marker in lowered for marker in TRAJECTORY_EVIDENCE_MARKERS):
+            return True
+    return False

--- a/src/gandalf/judge.py
+++ b/src/gandalf/judge.py
@@ -25,7 +25,33 @@ from openhands.tools.file_editor import FileEditorTool
 from openhands.tools.terminal import TerminalTool
 from pydantic import TypeAdapter
 
-from gandalf.models import BatchJudgeInput, JudgeInput, LLMUsage, MCPServer, Verdict
+from gandalf.guidance_evidence import (
+    extract_score_calibration_ceiling,
+    has_action_side_effect_audit,
+    has_output_location_conflict_audit,
+    has_score_calibration_audit,
+    has_score_calibration_audit_marker,
+    has_source_availability_audit,
+    has_source_guidance_conflict_audit,
+    has_source_guidance_conflict_language,
+    has_source_verification_audit,
+    has_trajectory_evidence,
+    has_workspace_artifact_evidence,
+    requires_above_midpoint_justification,
+    requires_action_side_effect_audit,
+    requires_output_location_conflict_audit,
+    requires_source_availability_audit,
+    requires_source_verification_audit,
+)
+from gandalf.models import (
+    BatchJudgeInput,
+    GuidanceJudgeInput,
+    GuidanceScore,
+    JudgeInput,
+    LLMUsage,
+    MCPServer,
+    Verdict,
+)
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 
@@ -86,6 +112,29 @@ def build_batch_judge_prompt(
         criteria=criteria,
         verdict_path=verdict_path,
         judge_guidance=judge_guidance,
+    )
+
+
+def build_guidance_judge_prompt(
+    instructions: str,
+    final_output: str,
+    judge_guidance: str,
+    trajectory_path: str,
+    score_path: str,
+    judge_prompt: str | None = None,
+    workspace_path: str | None = None,
+) -> str:
+    """Build the user message sent to kick off a guidance-mode judge session."""
+    return render_template(
+        "judge_guidance.j2",
+        judge_prompt,
+        instructions=instructions,
+        final_output=final_output,
+        judge_guidance=judge_guidance,
+        trajectory_path=trajectory_path,
+        score_path=score_path,
+        workspace_path=workspace_path or "",
+        workdir=workspace_path or "",
     )
 
 
@@ -164,6 +213,81 @@ def read_batch_verdict(verdict_path: str, n_criteria: int) -> list[Verdict]:
         )
     else:
         return results
+
+
+def read_guidance_score(
+    score_path: str,
+    *,
+    require_action_side_effect_audit: bool = False,
+    require_output_location_conflict_audit: bool = False,
+    require_source_availability_audit: bool = False,
+    require_source_verification_audit: bool = False,
+) -> GuidanceScore:
+    """Read and validate the holistic guidance score written by the judge agent."""
+    try:
+        with open(score_path) as f:
+            content = f.read().strip()
+        if not content:
+            return GuidanceScore.error("Judge agent wrote an empty guidance score file.")
+
+        data = json.loads(content)
+        if not isinstance(data, dict):
+            return GuidanceScore.error(f"Expected JSON object, got {type(data).__name__}.")
+
+    except FileNotFoundError:
+        return GuidanceScore.error("Judge agent did not write a guidance score file.")
+    except json.JSONDecodeError as e:
+        return GuidanceScore.error(f"Judge agent wrote invalid JSON: {e}")
+    else:
+        score = GuidanceScore.from_raw(data)
+
+        def reject_score(reason: str) -> GuidanceScore:
+            return score.model_copy(update={"score": None, "reasoning": reason})
+
+        validation_errors: list[str] = []
+        if score.score is not None:
+            if not has_score_calibration_audit(score.evidence):
+                if has_score_calibration_audit_marker(score.evidence):
+                    validation_errors.append(
+                        'invalid "Score calibration/cap audit" evidence item: include a parseable concrete '
+                        'numeric maximum such as "maximum score allowed is 0.65"'
+                    )
+                else:
+                    validation_errors.append('missing required "Score calibration/cap audit" evidence item')
+            score_ceiling = extract_score_calibration_ceiling(score.evidence)
+            if score_ceiling is not None and score.score > score_ceiling:
+                validation_errors.append(
+                    f"score {score.score} exceeds score calibration/cap audit ceiling {score_ceiling}"
+                )
+            if requires_above_midpoint_justification(
+                score.score,
+                score_ceiling,
+                reasoning=score.reasoning,
+                evidence=score.evidence,
+            ):
+                validation_errors.append(
+                    "near declared ceiling with foundational failure language requires an explicit "
+                    "above-midpoint justification in the Score calibration/cap audit"
+                )
+            if not has_workspace_artifact_evidence(score.evidence):
+                validation_errors.append("missing required workspace/artifact evidence item")
+            if not has_trajectory_evidence(score.evidence):
+                validation_errors.append("missing required trajectory evidence item")
+            if require_output_location_conflict_audit and not has_output_location_conflict_audit(score.evidence):
+                validation_errors.append('missing required "Output-location conflict audit" evidence item')
+            if require_action_side_effect_audit and not has_action_side_effect_audit(score.evidence):
+                validation_errors.append('missing required "Action/side-effect audit" evidence item')
+            if require_source_availability_audit and not has_source_availability_audit(score.evidence):
+                validation_errors.append('missing required "Source availability audit" evidence item')
+            if require_source_verification_audit and not has_source_verification_audit(score.evidence):
+                validation_errors.append('missing required "Source verification audit" evidence item')
+            if any(has_source_guidance_conflict_language(part) for part in [score.reasoning, *score.evidence]) and not (
+                has_source_guidance_conflict_audit(score.evidence)
+            ):
+                validation_errors.append('missing required "Source/guidance conflict audit" evidence item')
+            if validation_errors:
+                return reject_score("Guidance score validation failed: " + "; ".join(validation_errors) + ".")
+        return score
 
 
 def make_verdict_path(prefix: str = "verdict_", directory: str | None = None) -> str:
@@ -336,6 +460,56 @@ def run_judge_batch(input_path: str, output_path: str) -> None:
         json.dump(output, f, indent=2)
 
 
+def run_judge_guidance(input_path: str, output_path: str) -> None:
+    """Run the agent-as-judge for one holistic grading-guidance evaluation."""
+    with open(input_path) as f:
+        judge_input = GuidanceJudgeInput.model_validate_json(f.read())
+
+    score_path = make_verdict_path(prefix="guidance_score_", directory=judge_input.workdir)
+
+    prompt = build_guidance_judge_prompt(
+        instructions=judge_input.instructions,
+        final_output=judge_input.final_output,
+        judge_guidance=judge_input.judge_guidance,
+        trajectory_path=judge_input.trajectory_path,
+        score_path=score_path,
+        judge_prompt=judge_input.judge_prompt,
+        workspace_path=judge_input.workdir,
+    )
+
+    llm_usage = LLMUsage()
+    try:
+        llm_usage = run_agent_session(judge_input.model, judge_input.mcp_servers, judge_input.workdir, prompt)
+        guidance_score = read_guidance_score(
+            score_path,
+            require_action_side_effect_audit=requires_action_side_effect_audit(
+                judge_input.instructions,
+                judge_input.judge_guidance,
+            ),
+            require_output_location_conflict_audit=requires_output_location_conflict_audit(
+                judge_input.instructions,
+                judge_input.judge_guidance,
+            ),
+            require_source_availability_audit=requires_source_availability_audit(
+                judge_input.instructions,
+                judge_input.judge_guidance,
+            ),
+            require_source_verification_audit=requires_source_verification_audit(
+                judge_input.instructions,
+                judge_input.judge_guidance,
+            ),
+        )
+    except Exception as e:  # noqa: BLE001
+        guidance_score = GuidanceScore.error(f"Judge execution error: {e}")
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(score_path)
+
+    output = {"guidance_score": guidance_score.model_dump(), "llm_usage": llm_usage.model_dump()}
+    with open(output_path, "w") as f:
+        json.dump(output, f, indent=2)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Judge rubric criterion")
     parser.add_argument("--input", required=True, help="Path to judge input JSON")
@@ -345,9 +519,19 @@ def main() -> None:
         action="store_true",
         help="Batch mode: evaluate all criteria in a single agent session",
     )
+    parser.add_argument(
+        "--guidance",
+        action="store_true",
+        help="Guidance mode: run one holistic grading-guidance session",
+    )
     args = parser.parse_args()
 
-    if args.batch:
+    if args.batch and args.guidance:
+        parser.error("--batch and --guidance are mutually exclusive")
+
+    if args.guidance:
+        run_judge_guidance(args.input, args.output)
+    elif args.batch:
         run_judge_batch(args.input, args.output)
     else:
         run_judge(args.input, args.output)

--- a/src/gandalf/models.py
+++ b/src/gandalf/models.py
@@ -73,6 +73,7 @@ class GraderConfig(BaseModel):
     """
 
     model: str = "gemini/gemini-2.5-flash"
+    grading_mode: Literal["rubric", "guidance"] = "rubric"
     instructions: str | None = None
     instructions_path: str | None = None
     rubric: list[RubricItem] | None = None
@@ -101,18 +102,39 @@ class GraderConfig(BaseModel):
         if self.rubric is not None and self.rubric_path is not None:
             msg = "Cannot set both 'rubric' and 'rubric_path'"
             raise ValueError(msg)
-        if self.rubric is None and self.rubric_path is None:
-            msg = "Must set either 'rubric' or 'rubric_path'"
-            raise ValueError(msg)
         if self.judge_guidance is not None and self.judge_guidance_path is not None:
             msg = "Cannot set both 'judge_guidance' and 'judge_guidance_path'"
             raise ValueError(msg)
         if self.judge_prompt is not None and self.judge_prompt_path is not None:
             msg = "Cannot set both 'judge_prompt' and 'judge_prompt_path'"
             raise ValueError(msg)
-        if self.batch_splits is not None and self.mode != "batch":
-            msg = "'batch_splits' can only be used with mode='batch'"
-            raise ValueError(msg)
+
+        if self.grading_mode == "rubric":
+            if self.rubric is None and self.rubric_path is None:
+                msg = "Must set either 'rubric' or 'rubric_path'"
+                raise ValueError(msg)
+            if self.batch_splits is not None and self.mode != "batch":
+                msg = "'batch_splits' can only be used with mode='batch'"
+                raise ValueError(msg)
+        else:
+            if self.rubric is not None or self.rubric_path is not None:
+                msg = "Do not set 'rubric' or 'rubric_path' when grading_mode='guidance'"
+                raise ValueError(msg)
+            if self.judge_guidance is None and self.judge_guidance_path is None:
+                msg = "Must set either 'judge_guidance' or 'judge_guidance_path' when grading_mode='guidance'"
+                raise ValueError(msg)
+            if self.judge_guidance is not None and not self.judge_guidance.strip():
+                msg = "'judge_guidance' must not be empty when grading_mode='guidance'"
+                raise ValueError(msg)
+            if self.batch_splits is not None:
+                msg = "'batch_splits' cannot be used when grading_mode='guidance'"
+                raise ValueError(msg)
+            if self.batch_timeout is not None:
+                msg = "'batch_timeout' cannot be used when grading_mode='guidance'"
+                raise ValueError(msg)
+            if self.max_concurrency is not None:
+                msg = "'max_concurrency' cannot be used when grading_mode='guidance'"
+                raise ValueError(msg)
         return self
 
 
@@ -142,6 +164,12 @@ class BatchJudgeInput(_BaseJudgeInput):
     """
 
     criteria: list[str]
+
+
+class GuidanceJudgeInput(_BaseJudgeInput):
+    """Input passed to the inner judge for one holistic guidance evaluation."""
+
+    trajectory_path: str
 
 
 class LLMUsage(BaseModel):
@@ -185,6 +213,51 @@ class Verdict(BaseModel):
         return [cls(met=None, reasoning=reason) for _ in range(n)]
 
 
+class GuidanceScore(BaseModel):
+    """Holistic score returned by guidance-mode judging."""
+
+    score: float | None
+    reasoning: str
+    evidence: list[str] = Field(default_factory=list)
+
+    @classmethod
+    def from_raw(cls, data: dict[str, Any]) -> "GuidanceScore":
+        """Create a GuidanceScore from a raw JSON-parsed dict, validating score bounds."""
+        if "score" not in data:
+            return cls(score=None, reasoning="Guidance score missing 'score' field.")
+
+        raw_score = data.get("score")
+        if isinstance(raw_score, bool) or not isinstance(raw_score, (int, float)):
+            return cls(score=None, reasoning="Guidance score must be numeric in the range [0, 1].")
+
+        score = float(raw_score)
+        if score < 0.0 or score > 1.0:
+            return cls(score=None, reasoning=f"Guidance score {score} is outside the valid range [0, 1].")
+
+        reasoning = str(data.get("reasoning", "")).strip()
+        if not reasoning:
+            return cls(score=None, reasoning="Guidance score missing non-empty 'reasoning' field.")
+
+        evidence = data.get("evidence")
+        if not isinstance(evidence, list):
+            return cls(score=None, reasoning="Guidance score must include an 'evidence' array.")
+
+        evidence_items = [str(item).strip() for item in evidence if str(item).strip()]
+        if not evidence_items:
+            return cls(score=None, reasoning="Guidance score must include at least one evidence item.")
+
+        return cls(
+            score=score,
+            reasoning=reasoning,
+            evidence=evidence_items,
+        )
+
+    @classmethod
+    def error(cls, reason: str) -> "GuidanceScore":
+        """Return an invalid score with an error reason."""
+        return cls(score=None, reasoning=reason, evidence=[])
+
+
 class CriterionResult(BaseModel):
     """Result for a single criterion evaluation."""
 
@@ -206,6 +279,19 @@ class EvaluationInfo(BaseModel):
     llm_usage: LLMUsage = Field(default_factory=LLMUsage)
     errored_criterion_count: int = 0
     evaluated_criteria_pct: float = 100.0
+
+
+class GuidanceEvaluationInfo(BaseModel):
+    """Detailed guidance-mode evaluation output."""
+
+    grading_mode: Literal["guidance"] = "guidance"
+    reward: float | None
+    score: float | None
+    reasoning: str
+    evidence: list[str] = Field(default_factory=list)
+    llm_usage: LLMUsage = Field(default_factory=LLMUsage)
+    errored: bool = False
+    error: str | None = None
 
 
 def load_config(path: str) -> GraderConfig:

--- a/src/gandalf/orchestrator.py
+++ b/src/gandalf/orchestrator.py
@@ -34,6 +34,9 @@ from gandalf.models import (
     CriterionResult,
     EvaluationInfo,
     GraderConfig,
+    GuidanceEvaluationInfo,
+    GuidanceJudgeInput,
+    GuidanceScore,
     JudgeInput,
     LLMUsage,
     RubricItem,
@@ -341,6 +344,137 @@ def run_judge(
         shutil.rmtree(clone_dir, ignore_errors=True)
 
 
+def copy_trajectory_to_workspace(trajectory_path: str, clone_dir: str) -> str:
+    """Copy the ATIF trajectory into the cloned judge workspace and return its path."""
+    dst = os.path.join(clone_dir, "gandalf_trajectory.json")
+    shutil.copyfile(trajectory_path, dst)
+    os.chmod(dst, 0o644)
+    return dst
+
+
+def guidance_score_from_payload(raw: object) -> GuidanceScore:
+    """Parse the nested guidance_score payload from the inner judge output."""
+    if not isinstance(raw, dict):
+        return GuidanceScore.error(f"Expected guidance_score object, got {type(raw).__name__}.")
+
+    evidence_raw = raw.get("evidence", [])
+    evidence = [str(item) for item in evidence_raw] if isinstance(evidence_raw, list) else [str(evidence_raw)]
+
+    # The inner judge wrapper uses score=None to signal parse/infrastructure
+    # failures and preserves the specific reason.  Keep that reason intact.
+    if "score" in raw and raw.get("score") is None:
+        return GuidanceScore(
+            score=None,
+            reasoning=str(raw.get("reasoning", "Guidance score was invalid.")),
+            evidence=evidence,
+        )
+
+    return GuidanceScore.from_raw(raw)
+
+
+def round_guidance_score(score: GuidanceScore) -> GuidanceScore:
+    """Round a valid guidance score to the public reward precision."""
+    if score.score is None:
+        return score
+    return score.model_copy(update={"score": round(score.score, 4)})
+
+
+def run_guidance_judge(
+    judge_input: GuidanceJudgeInput,
+    sandbox_user: str | None,
+    trace_path: str,
+    timeout: int = 300,
+) -> tuple[GuidanceScore, LLMUsage]:
+    """Clone workspace, run the guidance judge subprocess, and return score + usage."""
+
+    def fail(msg: str, usage: LLMUsage | None = None) -> tuple[GuidanceScore, LLMUsage]:
+        return GuidanceScore.error(msg), usage or LLMUsage()
+
+    clone_dir: str | None = None
+    try:
+        clone_dir = clone_workspace(judge_input.workdir)
+        cloned_trajectory_path = copy_trajectory_to_workspace(judge_input.trajectory_path, clone_dir)
+    except Exception as e:  # noqa: BLE001
+        if clone_dir is not None:
+            shutil.rmtree(clone_dir, ignore_errors=True)
+        return fail(f"Failed to prepare guidance judge workspace: {e}")
+
+    assert clone_dir is not None  # noqa: S101
+    cloned_input = judge_input.model_copy(
+        update={
+            "workdir": clone_dir,
+            "trajectory_path": cloned_trajectory_path,
+        }
+    )
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".json",
+        prefix="judge_guidance_input_",
+        dir=clone_dir,
+        delete=False,
+    ) as input_f:
+        input_f.write(cloned_input.model_dump_json())
+        input_path = input_f.name
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".json",
+        prefix="judge_guidance_output_",
+        dir=clone_dir,
+        delete=False,
+    ) as output_f:
+        output_path = output_f.name
+    os.chmod(output_path, 0o666)  # noqa: S103
+
+    try:
+        os.chmod(input_path, 0o644)
+        env_vars = [f"HOME={clone_dir}", *judge_env_vars()]
+
+        cmd = []
+        if sandbox_user is not None:
+            cmd += ["sudo", "-u", sandbox_user]
+        cmd += [
+            "env",
+            *env_vars,
+            "gandalf-the-grader-judge",
+            "--input",
+            input_path,
+            "--output",
+            output_path,
+            "--guidance",
+        ]
+
+        result = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=clone_dir,
+        )
+
+        save_trace(trace_path, result.stdout, result.stderr, result.returncode)
+
+        if result.returncode != 0:
+            return fail(f"Judge process failed (exit {result.returncode}): {result.stderr[:500]}")
+
+        with open(output_path) as f:
+            data = json.load(f)
+
+    except subprocess.TimeoutExpired:
+        save_trace(trace_path, "", "Judge execution timed out.", -1)
+        return fail("Judge execution timed out.")
+    except (json.JSONDecodeError, FileNotFoundError) as e:
+        return fail(f"Failed to read judge output: {e}")
+    else:
+        usage = LLMUsage.model_validate(data.get("llm_usage", {}))
+        score = round_guidance_score(guidance_score_from_payload(data.get("guidance_score")))
+        return score, usage
+    finally:
+        shutil.rmtree(clone_dir, ignore_errors=True)
+
+
 def save_trace(trace_path: str, stdout: str, stderr: str, returncode: int) -> None:
     """Write the judge's stdout/stderr to a trace file."""
     with contextlib.suppress(OSError), open(trace_path, "w") as f:
@@ -593,6 +727,126 @@ def run_batch_concurrent(
     return results, total_usage
 
 
+def run_guidance_retry_guidance(
+    judge_guidance: str,
+    failed_scores: GuidanceScore | list[GuidanceScore],
+) -> str:
+    """Append validation-failure context for a guidance-mode retry."""
+    failures = [failed_scores] if isinstance(failed_scores, GuidanceScore) else failed_scores
+    combined_failure_reasoning = " ".join(score.reasoning for score in failures).lower()
+    feedback_lines = [
+        "",
+        "<previous_guidance_judge_validation_failure>",
+        "The previous guidance judge output was rejected before a reward could be accepted.",
+        "Validation failure history:",
+        *[f"{idx}. {score.reasoning}" for idx, score in enumerate(failures, start=1)],
+        (
+            "On this retry, perform a fresh holistic evaluation using the same grading standards; "
+            "do not change the score merely to satisfy validation. Correct the missing or invalid "
+            "score/evidence contract while still grading the final artifacts and trajectory accurately."
+        ),
+    ]
+    if "above-midpoint" in combined_failure_reasoning:
+        feedback_lines.extend(
+            [
+                "Above-midpoint validation repair:",
+                (
+                    'In the "Score calibration/cap audit" evidence item, include a sentence like: '
+                    '"The score is above the midpoint because <name the central requirements that were '
+                    'fully satisfied>, but remains below the ceiling because <name the foundational failures>."'
+                ),
+                "Name the central requirements that justify above-midpoint placement; do not raise the score solely to satisfy validation.",
+            ]
+        )
+    if (
+        "source availability audit" in combined_failure_reasoning
+        or "source verification audit" in combined_failure_reasoning
+    ):
+        feedback_lines.extend(
+            [
+                "Source audit validation repair:",
+                (
+                    'Use the exact audit labels the validator requires. Include "Source availability audit:" '
+                    "when named expected sources were accessible, missing, or only visible in the trajectory."
+                ),
+                (
+                    'Include "Source verification audit:" when the task or guidance required independent '
+                    "source-of-truth checks, recomputation, or source-backed numerical verification."
+                ),
+                "Do not hide those checks under generic labels such as trajectory/source check or artifact check.",
+            ]
+        )
+    evidence_excerpt_lines: list[str] = []
+    for idx, score in enumerate(failures, start=1):
+        if score.evidence:
+            evidence_excerpt_lines.append(f"Attempt {idx} rejected evidence excerpt:")
+            evidence_excerpt_lines.extend(f"- {item}" for item in score.evidence[:5])
+    if evidence_excerpt_lines:
+        feedback_lines.append("Previous rejected evidence excerpts:")
+        feedback_lines.extend(evidence_excerpt_lines)
+    feedback_lines.append("</previous_guidance_judge_validation_failure>")
+    return f"{judge_guidance.rstrip()}\n\n" + "\n".join(feedback_lines).strip()
+
+
+def run_guidance(
+    config: GraderConfig,
+    final_output: str,
+    instructions: str,
+    judge_guidance: str,
+    judge_prompt: str | None,
+) -> tuple[GuidanceScore, LLMUsage, bool]:
+    """Run one holistic guidance judge session, retrying invalid/error scores."""
+    judge_input = GuidanceJudgeInput(
+        model=config.model,
+        instructions=instructions,
+        final_output=final_output,
+        workdir=config.workdir,
+        trajectory_path=config.trajectory_path,
+        mcp_servers=config.mcp_servers,
+        judge_guidance=judge_guidance,
+        judge_prompt=judge_prompt,
+    )
+
+    total_usage = LLMUsage()
+    latest_score = GuidanceScore.error("Guidance judge did not run.")
+    failed_scores: list[GuidanceScore] = []
+    initial_errored = False
+
+    for attempt in range(config.judge_retries + 1):
+        attempt_judge_input = judge_input
+        if attempt == 0:
+            print(f"[guidance] Evaluating holistic score (timeout={config.judge_timeout}s)...")  # noqa: T201
+            trace_path = os.path.join(config.output_dir, "judge_trace_guidance.txt")
+        else:
+            print(  # noqa: T201
+                f"\n[retry {attempt}/{config.judge_retries}] Retrying guidance score..."
+            )
+            trace_path = os.path.join(config.output_dir, f"judge_trace_guidance_retry{attempt}.txt")
+            attempt_judge_input = judge_input.model_copy(
+                update={
+                    "judge_guidance": run_guidance_retry_guidance(judge_guidance, failed_scores),
+                }
+            )
+
+        latest_score, usage = run_guidance_judge(
+            attempt_judge_input,
+            sandbox_user=config.sandbox_user,
+            trace_path=trace_path,
+            timeout=config.judge_timeout,
+        )
+        latest_score = round_guidance_score(latest_score)
+        total_usage = total_usage + usage
+
+        if attempt == 0:
+            initial_errored = latest_score.score is None
+
+        if latest_score.score is not None:
+            break
+        failed_scores.append(latest_score)
+
+    return latest_score, total_usage, initial_errored
+
+
 def get_errored_indices(results: list[CriterionResult]) -> list[int]:
     """Return indices of criteria where met is None (infrastructure error)."""
     return [i for i, r in enumerate(results) if r.met is None]
@@ -654,6 +908,29 @@ def write_info(
     return reward, raw_score
 
 
+def write_guidance_info(
+    config: GraderConfig,
+    guidance_score: GuidanceScore,
+    llm_usage: LLMUsage,
+    *,
+    errored: bool,
+) -> float | None:
+    """Write guidance-mode info.json and return the reward when available."""
+    reward = round(guidance_score.score, 4) if guidance_score.score is not None else None
+    info = GuidanceEvaluationInfo(
+        reward=reward,
+        score=reward,
+        reasoning=guidance_score.reasoning,
+        evidence=guidance_score.evidence,
+        llm_usage=llm_usage,
+        errored=errored,
+        error=guidance_score.reasoning if errored else None,
+    )
+    with open(os.path.join(config.output_dir, "info.json"), "w") as f:
+        f.write(info.model_dump_json(indent=2))
+    return reward
+
+
 def check_tmux_available() -> None:
     """Verify tmux is installed and usable.
 
@@ -698,17 +975,63 @@ def main() -> None:
 
     instructions = resolve_instructions(config)
 
-    # The model validator guarantees exactly one of rubric / rubric_path is set.
-    if config.rubric is not None:
-        rubric = config.rubric
-    else:
-        assert config.rubric_path is not None  # noqa: S101  # guaranteed by model validator
-        rubric = load_rubric(config.rubric_path)
     final_output = load_trajectory_final_output(config.trajectory_path)
     judge_guidance = resolve_judge_guidance(config)
     judge_prompt = resolve_judge_prompt(config)
 
     os.makedirs(config.output_dir, exist_ok=True)
+
+    if config.grading_mode == "guidance":
+        if not judge_guidance.strip():
+            guidance_score = GuidanceScore.error("No judge guidance provided for guidance mode.")
+            write_guidance_info(config, guidance_score, LLMUsage(), errored=True)
+            print(  # noqa: T201
+                "ERROR: guidance mode requires non-empty judge_guidance or judge_guidance_path.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        guidance_score, llm_usage, guidance_initial_errored = run_guidance(
+            config,
+            final_output,
+            instructions,
+            judge_guidance,
+            judge_prompt,
+        )
+        guidance_errored = guidance_score.score is None
+        reward = write_guidance_info(config, guidance_score, llm_usage, errored=guidance_errored)
+
+        if guidance_errored:
+            print(  # noqa: T201
+                f"\nERROR: guidance score could not be produced "
+                f"(initial error: {guidance_initial_errored}, after retries: true).",
+                file=sys.stderr,
+            )
+            print(f"info.json written to {config.output_dir}/ (reward.json NOT written)", file=sys.stderr)  # noqa: T201
+            sys.exit(1)
+
+        assert reward is not None  # noqa: S101
+        with open(os.path.join(config.output_dir, "reward.json"), "w") as f:
+            json.dump({"reward": reward}, f, indent=2)
+
+        print(f"\nReward: {reward}")  # noqa: T201
+        if llm_usage.cost_usd > 0:
+            print(  # noqa: T201
+                f"Grader LLM cost: ${llm_usage.cost_usd:.4f} "
+                f"({llm_usage.prompt_tokens} prompt + {llm_usage.completion_tokens} completion tokens)"
+            )
+        print("Mode: guidance")  # noqa: T201
+        if guidance_initial_errored:
+            print("Retried: guidance score recovered after retry")  # noqa: T201
+        print(f"Results written to {config.output_dir}/")  # noqa: T201
+        return
+
+    # The model validator guarantees exactly one of rubric / rubric_path is set in rubric mode.
+    if config.rubric is not None:
+        rubric = config.rubric
+    else:
+        assert config.rubric_path is not None  # noqa: S101  # guaranteed by model validator
+        rubric = load_rubric(config.rubric_path)
 
     if config.mode == "batch":
         splits = config.batch_splits

--- a/src/gandalf/templates/judge_guidance.j2
+++ b/src/gandalf/templates/judge_guidance.j2
@@ -1,0 +1,106 @@
+You are an expert judge evaluating an AI agent's completed task holistically from grading guidance. You have access to the agent's working directory and can inspect files, run commands, and use tools to investigate.
+
+<judge_guidance>
+{{ judge_guidance }}
+</judge_guidance>
+
+<task_instructions>
+{{ instructions }}
+</task_instructions>
+
+<agent_final_output>
+{{ final_output }}
+</agent_final_output>
+
+<workspace_path>
+{{ workspace_path }}
+</workspace_path>
+
+<trajectory_file>
+{{ trajectory_path }}
+</trajectory_file>
+
+<judge_instructions>
+Assign one final score in the range [0, 1] for how well the agent completed the task.
+
+You MUST inspect both:
+- the final artifacts and current state in the workspace
+- the trajectory file listed above, using it as needed to understand the agent's actions, tool use, errors, and final state
+
+The workspace path above is the cloned judge workspace containing the final captured artifact state. Treat relative artifact paths as relative to this workspace path. If task instructions, grading guidance, or trajectory entries mention original container paths such as /home/agent/workspace, /workspace, /workdir, or /tmp/workdir, first look for the corresponding file or directory under the cloned judge workspace before declaring it missing or inaccessible. For example, an original /home/agent/workspace/deliverables path is usually represented as workspace_path/deliverables inside this judge session.
+
+Before checking original absolute paths, first inventory the cloned workspace path itself. A useful shell pattern is:
+  WORKSPACE_PATH="{{ workspace_path }}"; find "$WORKSPACE_PATH" -maxdepth 4 -type f | sort
+Do not declare an artifact missing or inaccessible from checks against /home/agent/workspace, /workspace, /workdir, /tmp/workdir, or /tmp/output until you have inspected the cloned workspace path and mapped likely captured equivalents such as workspace_path/deliverables, workspace_path/output, and workspace_path/tmp/output. If a required artifact is present in the cloned workspace under a task-instructed path, treat it as accessible and explain any remaining output-location conflict separately.
+
+After inventorying the workspace, classify the deliverable types you actually found (for example: xlsx, pptx, docx, pdf, csv, json, html, markdown, plain text, code, or missing expected artifacts) before doing format-specific checks. Let the actual deliverable types and the task/guidance determine the inspection method. Do not apply office-document-specific checks to non-office outputs unless the task or grading guidance required an office document and the absence itself is the issue.
+
+Keep artifact inspection batched and bounded. For large workbooks, documents, slide decks, logs, trajectories, or JSON files, prefer a short script or targeted command that checks many required criteria at once; print findings or verdicts with key supporting values. Do not dump whole workbooks, whole documents, or whole trajectory/tool-output files into the conversation. If output is long, filter it, summarize it, or read it in chunks.
+
+For office-style artifacts, use evidence appropriate to the format. For spreadsheets, inspect formula text when formulas are required, and recalculate or otherwise verify cached values when cached values matter; do not treat a formula-engine limitation as an agent error without checking the formula text. For slides, charts, document layout, formatting, and visual or layout claims, use rendered screenshot or exported/rendered evidence when available before relying only on programmatic properties.
+
+For source or reference spreadsheets used as a book of record, distinguish formula text from cached/displayed values. If a source workbook cell contains a formula but no cached value, do not recompute source-workbook formulas yourself and treat the result as posted or displayed book-of-record actuals unless the grading guidance explicitly instructs you to do so. When this distinction affects grading, include a "Formula cache/source-value audit" evidence item explaining which cells had formulas without cached values, which cells had posted/displayed literal values, and how that affected score.
+
+Do not assume the final output is the whole trajectory. It is useful context, but the trajectory file is the complete record available to you.
+
+Distinguish task inputs, source files, reference files, and golden files from agent outputs. Reference or golden files are not agent-produced outputs; use them as comparison baselines or source-of-truth files when the task or grading guidance names them, and compare the output against them where relevant. Do not treat an unchanged input/template/reference file as a completed output unless the task explicitly allowed that.
+
+Use the grading guidance for scoring semantics and domain-specific expectations. If the guidance contains its own output-format instructions, ignore only those output-format instructions and follow the JSON contract below instead. Do not ignore substantive grading instructions.
+
+This is guidance-mode grading. Refer to these instructions as grading guidance, judge guidance, or guidance. Do not call them a rubric, and do not imply that a rubric is available unless the grading guidance text itself explicitly says so.
+
+The task instructions are the primary user-facing contract for what the agent was asked to do; the grading guidance explains how to evaluate that work. If the task instructions and grading guidance conflict, explicitly reconcile the conflict in your reasoning or evidence. For output location conflicts, do not penalize an otherwise accessible artifact solely because it was saved to a task-instructed path instead of a different harness or grading-guidance path, unless the grading guidance clearly says the task-instructed path itself must be treated as wrong. Before applying any output-location penalty, compare the locations named in the task instructions, grading guidance, final artifacts, and trajectory, and include an "Output-location conflict audit" evidence item explaining whether the actual location was task-instructed, guidance-instructed, both, neither, missing, or inaccessible. Do still penalize missing, inaccessible, or misplaced artifacts when neither the task instructions nor the grading guidance support the actual location.
+
+If grading guidance includes rule IDs, penalty rules, caps, point weights, or arithmetic formulas, only apply penalty rules when their stated conditions match the task instructions, actual deliverable types, and verified evidence. Do not penalize choices the task explicitly requested. Score against the task and grading guidance, not a hypothetical ideal: avoid ad-hoc conservatism deductions for polish, style, or extra thoroughness unless the guidance asks for them. If the guidance provides explicit arithmetic, compute it from the criteria you marked and penalties you applied; do not round or adjust the score to a "nice" number.
+
+Use this investigation procedure before choosing a score:
+1. Derive a short checklist of the concrete outcomes, constraints, source-of-truth expectations, output locations, and trajectory/workflow requirements implied by the task instructions and grading guidance.
+2. Inspect the final workspace/artifact state, not just file names. Open or parse deliverables with appropriate tools when needed, and verify important calculations, output locations, email/draft state, and missing artifacts against the checklist. When the task instructions or grading guidance name expected source files, databases, tools, exports, or connectors, first determine whether those sources are actually accessible to you in the cloned judge workspace, current system/tool state, or trajectory. Always include a "Source availability audit" evidence item for named expected sources, whether expected sources are available or missing, explaining which expected sources were accessible, which were not accessible, and how that changed any missing-source or supporting-context penalty. If expected sources are not accessible, do not score that the same as if the agent ignored an accessible source. Do not apply a missing-source cap or hard penalty solely because an inaccessible supporting source was absent after a reasonable source search; instead, grade the verified work against the accessible sources, disclosures, and any alternate sources the task or grading guidance allowed. Penalize more strongly when an agent ignored an accessible source, failed to perform a reasonable source search, fabricated unavailable-source details, or treated unavailable supporting data as proven. When the task instructions or grading guidance require independent verification, source-of-truth checks, recomputation, or source-backed numerical claims, include a "Source verification audit" evidence item that states what you independently verified or recomputed from source data and what you compared it against.
+3. Inspect the trajectory file for source choices, failed commands, retries, tool calls, email send/draft behavior, files created or copied, and any mismatch between what the agent did and what the final output claims. If the task instructions or grading guidance mention required or forbidden external actions, such as email drafts/sends, calendar events, QuickBooks/Shopify/Square updates, file submissions, or live actions, include an "Action/side-effect audit" evidence item that states which relevant trajectory tool calls or final-state artifacts you checked and whether the required actions happened or forbidden actions did not happen. When a live external artifact is required, such as an Outlook draft, calendar event, submitted form, or system update, a local file imitation such as a .txt/.html/.eml copy does not by itself prove that the required external action happened unless the task or grading guidance explicitly accepts that file artifact as sufficient; use the trajectory and accessible system state to decide whether to give full, partial, or missing credit.
+4. Reconcile the final output against both the artifacts and trajectory. Treat unsupported final-output claims as unproven.
+5. Build an explicit score calibration/cap audit: identify any score bands, score caps, hard penalties, completion standards, or "known failure mode" instructions in the grading guidance; determine the maximum score allowed by the verified evidence; and apply the strictest applicable cap. Treat guidance phrases such as "cap at", "should cap", "generally cap", "hard penalty", or "known failure mode" as score ceilings when the verified evidence matches them. Do not exceed that cap unless the grading guidance itself leaves discretion and your evidence explicitly justifies doing so. If a plausible cap or hard penalty is not applied, explain why it does not apply.
+6. Choose the score from verified task success, not artifact polish. Useful-looking artifacts should receive limited credit if they are built on the wrong source of truth, materially wrong core numbers, missing required outputs, or incorrect workflow actions.
+
+Mandatory evidence checklist:
+Use these exact evidence labels when the condition applies; do not rename these audit labels. If an expected check is genuinely unavailable, still include the exact audit label and explain why it was unavailable.
+- Always include a "Workspace/artifact check" evidence item for final artifact/state inspection.
+- Always include a "Trajectory check" evidence item for trajectory inspection.
+- Always include a "Score calibration/cap audit" evidence item with a parseable numeric maximum such as "maximum score allowed is 0.65" or "strictest applicable cap is 0.60".
+- When expected source files, databases, connectors, exports, or reference materials are named, include a "Source availability audit" evidence item.
+- When independent verification, source-of-truth checks, recomputation, or source-backed numerical claims are required, include a "Source verification audit" evidence item.
+- When required or forbidden external actions are part of the task or guidance, include an "Action/side-effect audit" evidence item.
+- When task instructions and guidance name conflicting output locations, include an "Output-location conflict audit" evidence item.
+- When accessible source data conflicts with grading-guidance checkpoints or expected figures, include a "Source/guidance conflict audit" evidence item.
+
+When grading guidance defines score bands, place the score within the applicable band based on the severity and centrality of the verified failures. Do not default to the top of an applicable band just because the result has the right format or many supporting details. If the result fails a foundational calculation, uses a wrong source of truth for a core analytical conclusion, leaves downstream dependent outputs materially wrong, or misses an explicit confirm/correct, verify/refute, or required-action requirement, score in the lower or middle part of the applicable band unless the guidance clearly says otherwise. Do not score near a declared ceiling when foundational requirement failures remain, such as a materially wrong central quantitative output, an unsupported core conclusion, missing required external verification, missing required deliverables or artifacts, or a workflow action that was required but not performed. A score near a cap or band ceiling is appropriate only when the cap is triggered by narrow issues and minor, non-core issues remain. Before choosing a score in the top quarter of a band, verify that the result satisfies nearly all requirements for the next higher band; if multiple central requirements for the next higher band are materially failed, move the score to the middle or lower part of the applicable band. If the evidence shows multiple central requirements are materially failed, compute the midpoint of the applicable band or declared ceiling range and choose a score at or below that midpoint unless you can name specific central requirements that were nevertheless fully satisfied and justify a higher placement. If you choose a score above the midpoint despite foundational failures, the "Score calibration/cap audit" evidence item must explicitly say the score is above the midpoint because specific central requirements were satisfied, and it must name those central requirements. When you describe a result as lower-band, middle-band, upper-band, near a boundary, or near a cap, the numeric score must match that placement word; do not call a score middle-of-band when it is actually in the top quarter of that band or close to the declared ceiling. Reserve scores near the top of a band for results that satisfy almost all requirements of that band and have only minor, non-core omissions.
+
+If accessible source data conflicts with a numeric checkpoint, expected figure, or golden value stated in the grading guidance, do not silently penalize source-grounded work as simply wrong. Include a "Source/guidance conflict audit" evidence item that states the conflicting values, which accessible source or reference produced each value, whether the agent used a defensible source, and why. Explain which source you treated as authoritative for scoring. Follow explicit grading-guidance authority when it clearly names a golden/reference source of truth, but explain the conflict rather than hiding it inside ordinary failure evidence.
+
+Your reasoning must briefly explain the main strengths, the main failures or omissions, whether the result is source-grounded, and why the chosen score is appropriate. If you applied a score cap or hard penalty, name it in the reasoning. If the score is near a band boundary, explain why it belongs on that side of the boundary. Your evidence must include concrete positive and negative checks when both exist. Include at least one workspace/artifact check, at least one trajectory check, and one "Score calibration/cap audit" evidence item that names the score band, any applicable caps or hard penalties, the maximum score allowed as a concrete numeric maximum, and any plausible cap you considered but did not apply. Avoid vague maximums such as "mid-0.6s" or "low-0.8 range"; write a parseable value such as "maximum score allowed is 0.65" or "strictest applicable cap is 0.60". When expected source files, databases, tools, exports, or connectors are named, your evidence must include one "Source availability audit" evidence item. When independent verification, source-of-truth checks, recomputation, or source-backed numerical claims are required, your evidence must include one "Source verification audit" evidence item. When required or forbidden external actions are part of the task or guidance, your evidence must include one "Action/side-effect audit" evidence item. If one class of evidence is genuinely unavailable, include an evidence item explaining why.
+
+When your investigation is complete, you MUST write your score as a JSON object to:
+  {{ score_path }}
+
+The score file is the ONLY output that will be read. If you do not write this file, the evaluation fails.
+
+The JSON object must have exactly these fields:
+- "score": a number from 0 to 1 inclusive
+- "reasoning": a non-empty concise explanation of the score
+- "evidence": a non-empty array of strings, each describing a concrete check you performed (e.g. file path and observed content, command output, trajectory event, or tool-returned value)
+
+Example:
+```json
+{
+  "score": 0.8,
+  "reasoning": "The final report is mostly correct but omits one requested comparison.",
+  "evidence": [
+    "Read /workspace/report.md: contains sections for A and B but no C comparison",
+    "Inspected trajectory file: agent attempted the C comparison but the command failed"
+  ]
+}
+```
+
+Write ONLY valid JSON to that file, with no additional text.
+
+YOUR FINAL ACTION must be: use file_editor tool (create command) to write the complete JSON object to {{ score_path }}. Do not finish or end your response until this file is written. Do not print the score in your response -- only the file on disk counts.
+</judge_instructions>

--- a/tests/test_harbor_scripts.py
+++ b/tests/test_harbor_scripts.py
@@ -1,0 +1,1139 @@
+"""Tests for Harbor rollout helper scripts."""
+
+import importlib.util
+import json
+import pathlib
+from types import ModuleType
+
+import pytest
+
+
+def load_index_module() -> ModuleType:
+    """Load scripts/index_harbor_rollouts.py without requiring scripts to be a package."""
+    module_path = pathlib.Path(__file__).parents[1] / "scripts" / "index_harbor_rollouts.py"
+    spec = importlib.util.spec_from_file_location("index_harbor_rollouts", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_script_module(name: str) -> ModuleType:
+    """Load a script module without requiring scripts to be a package."""
+    module_path = pathlib.Path(__file__).parents[1] / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_discover_rollout_records_maps_trial_to_harbor_task(tmp_path: pathlib.Path) -> None:
+    module = load_index_module()
+    tasks_root = tmp_path / "tasks"
+    task_dir = tasks_root / "sheet_env" / "rebalance_budget"
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "task.toml").write_text("name = 'rebalance_budget'\n")
+    (task_dir / "instruction.md").write_text("Do the task.")
+    (task_dir / "tests" / "judge_guidance.md").write_text("Grade holistically.")
+    (task_dir / "tests" / "rubric.json").write_text(json.dumps([]))
+
+    rollouts_root = tmp_path / "rollouts"
+    trial_dir = rollouts_root / "sheet_env__rebalance_budget" / "trial_0"
+    (trial_dir / "agent").mkdir(parents=True)
+    (trial_dir / "artifacts" / "workspace").mkdir(parents=True)
+    (trial_dir / "agent" / "trajectory.json").write_text(json.dumps({"steps": []}))
+
+    records = module.discover_rollout_records(rollouts_root, tasks_root)
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["slug"] == "sheet_env__rebalance_budget"
+    assert record["env"] == "sheet_env"
+    assert record["task"] == "rebalance_budget"
+    assert record["task_dir"] == str(task_dir)
+    assert record["instruction_path"] == str(task_dir / "instruction.md")
+    assert record["judge_guidance_path"] == str(task_dir / "tests" / "judge_guidance.md")
+    assert record["rubric_path"] == str(task_dir / "tests" / "rubric.json")
+    assert record["trajectory_path"] == str(trial_dir / "agent" / "trajectory.json")
+    assert record["workspace_path"] == str(trial_dir / "artifacts" / "workspace")
+
+
+def test_discover_rollout_records_ignores_artifact_trajectory_copy(tmp_path: pathlib.Path) -> None:
+    module = load_index_module()
+    tasks_root = tmp_path / "tasks"
+    task_dir = tasks_root / "sheet_env" / "rebalance_budget"
+    task_dir.mkdir(parents=True)
+    (task_dir / "instruction.md").write_text("Do the task.")
+    (task_dir / "judge_guidance.md").write_text("Grade holistically.")
+    (task_dir / "rubric.json").write_text(json.dumps([]))
+
+    rollouts_root = tmp_path / "rollouts"
+    trial_dir = rollouts_root / "sheet_env__rebalance_budget" / "trial_0"
+    (trial_dir / "agent").mkdir(parents=True)
+    (trial_dir / "artifacts" / "agent").mkdir(parents=True)
+    (trial_dir / "artifacts" / "workspace").mkdir(parents=True)
+    canonical_trajectory = trial_dir / "agent" / "trajectory.json"
+    artifact_copy = trial_dir / "artifacts" / "agent" / "trajectory.json"
+    canonical_trajectory.write_text(json.dumps({"source": "canonical"}))
+    artifact_copy.write_text(json.dumps({"source": "artifact"}))
+
+    records = module.discover_rollout_records(rollouts_root, tasks_root)
+
+    assert len(records) == 1
+    assert records[0]["trajectory_path"] == str(canonical_trajectory)
+
+
+def test_assign_splits_groups_same_slug_and_uses_all_splits() -> None:
+    module = load_script_module("split_harbor_manifest")
+    records = [{"env": "env-a", "slug": f"env-a__task-{i}", "trial_dir": f"/trial/{i}"} for i in range(9)]
+    records.append({"env": "env-a", "slug": "env-a__task-1", "trial_dir": "/trial/duplicate"})
+
+    split_records = module.assign_splits(records, seed="test-seed")
+    splits = {record["split"] for record in split_records}
+    assert splits == {"train", "eval", "test"}
+
+    by_slug: dict[str, set[str]] = {}
+    for record in split_records:
+        by_slug.setdefault(record["slug"], set()).add(record["split"])
+    assert all(len(split_values) == 1 for split_values in by_slug.values())
+
+
+def test_analyze_guidance_eval_uses_score_and_evidence_signals(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    rubric_path = tmp_path / "rubric.json"
+    rubric_path.write_text(
+        json.dumps(
+            [
+                {"criterion": "Workbook includes monthly revenue trend analysis", "weight": 1},
+                {"criterion": "Evidence cites trajectory command failures", "weight": 1},
+            ]
+        )
+    )
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text(
+        "Grade monthly revenue trend analysis. Require trajectory evidence, "
+        "score calibration/cap audit, and output-location conflict audit."
+    )
+    instruction_path = tmp_path / "instruction.md"
+    instruction_path.write_text("Prepare the workbook, but do not send email or create calendar events.")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "The workbook includes monthly revenue trend analysis but misses one detail.",
+                "evidence": [
+                    "Read /workspace/deliverables/report.xlsx",
+                    "Inspected trajectory command output for failures",
+                    "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    "Output-location conflict audit: artifact path matches task instructions.",
+                    "Action/side-effect audit: no email send or calendar event tool calls were present.",
+                ],
+            }
+        )
+    )
+    info_path_without_action = tmp_path / "guidance_info_without_action.json"
+    info_path_without_action.write_text(
+        json.dumps(
+            {
+                "reasoning": "The workbook includes monthly revenue trend analysis.",
+                "evidence": [
+                    "Read /workspace/deliverables/report.xlsx",
+                    "Inspected trajectory command output for failures",
+                    "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    "Output-location conflict audit: artifact path matches task instructions.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__task",
+            "trial_dir": "/trial",
+            "split": "eval",
+            "instruction_path": str(instruction_path),
+            "rubric_path": str(rubric_path),
+            "judge_guidance_path": str(guidance_path),
+        },
+        {
+            "slug": "env__task_without_action_requirement",
+            "trial_dir": "/trial-2",
+            "split": "eval",
+            "rubric_path": str(rubric_path),
+            "judge_guidance_path": str(guidance_path),
+        },
+    ]
+    rubric_results = [
+        {"slug": "env__task", "trial_dir": "/trial", "status": "ok", "reward": 0.75},
+        {"slug": "env__task_without_action_requirement", "trial_dir": "/trial-2", "status": "ok", "reward": 0.75},
+    ]
+    guidance_results = [
+        {
+            "slug": "env__task",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.8,
+            "info_path": str(info_path),
+        },
+        {
+            "slug": "env__task_without_action_requirement",
+            "trial_dir": "/trial-2",
+            "status": "ok",
+            "reward": 0.8,
+            "info_path": str(info_path_without_action),
+        },
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["abs_diff"] == 0.05
+    assert rows[0]["evidence_count"] == 5
+    assert rows[0]["has_file_or_path_evidence"] is True
+    assert rows[0]["mentions_trajectory_or_tools"] is True
+    assert rows[0]["guidance_vocab_coverage"] > 0
+    assert rows[0]["mentions_score_calibration_cap_audit"] is True
+    assert rows[0]["mentions_output_location_conflict_audit"] is True
+    assert rows[0]["mentions_action_side_effect_audit"] is True
+    assert rows[0]["requires_action_or_side_effect_check"] is True
+    assert rows[1]["mentions_action_side_effect_audit"] is False
+    assert rows[1]["requires_action_or_side_effect_check"] is False
+    assert "criterion_vocab_coverage" not in rows[0]
+    assert summary["by_split"]["eval"]["threshold_agreement_0_5"] == 1.0
+    assert summary["by_split"]["eval"]["mean_guidance_vocab_coverage"] > 0
+    assert summary["by_split"]["eval"]["pct_mentions_action_side_effect_audit"] == 0.5
+    assert summary["by_split"]["eval"]["pct_mentions_action_side_effect_audit_when_required"] == 1.0
+
+
+def test_analyze_guidance_eval_flags_likely_rubric_task_mismatch(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    aligned_rubric_path = tmp_path / "aligned_rubric.json"
+    aligned_rubric_path.write_text(
+        json.dumps(
+            [
+                {"criterion": "Workbook includes FY2025 Shopify revenue trend by month.", "weight": 1},
+                {"criterion": "Workbook compares Astor Apparel actuals to the P&L budget and buy plans.", "weight": 1},
+                {
+                    "criterion": "Workbook flags QuickBooks expense limitations and TimeStation missing wage rates.",
+                    "weight": 1,
+                },
+            ]
+        )
+    )
+    mismatched_rubric_path = tmp_path / "mismatched_rubric.json"
+    mismatched_rubric_path.write_text(
+        json.dumps(
+            [
+                {
+                    "criterion": "The deliverable is a Word docx file for a Curated Prestige May 2026 campaign brief.",
+                    "weight": 1,
+                },
+                {
+                    "criterion": "The brief recommends Instagram stories, Square checkout links, and a handbag shipping incentive.",
+                    "weight": 1,
+                },
+                {
+                    "criterion": "The brief reports open accounts payable and overdue vendor balances for the campaign.",
+                    "weight": 1,
+                },
+            ]
+        )
+    )
+    instruction_path = tmp_path / "instruction.md"
+    instruction_path.write_text(
+        "Prepare an Astor Apparel FY2025 Excel workbook covering Shopify revenue trend, budget comparison, "
+        "QuickBooks expenses, TimeStation labor limits, concentration, and recommended next steps."
+    )
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text(
+        "Grade the Astor Apparel FY2025 performance review workbook using Shopify orders, Astor budget files, "
+        "buy plans, QuickBooks bills, and TimeStation source records."
+    )
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "Checked the workbook.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/deliverables/report.xlsx.",
+                    "Trajectory check: inspected tool calls.",
+                    "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__aligned",
+            "trial_dir": "/trial-1",
+            "split": "eval",
+            "instruction_path": str(instruction_path),
+            "judge_guidance_path": str(guidance_path),
+            "rubric_path": str(aligned_rubric_path),
+        },
+        {
+            "slug": "env__mismatched",
+            "trial_dir": "/trial-2",
+            "split": "eval",
+            "instruction_path": str(instruction_path),
+            "judge_guidance_path": str(guidance_path),
+            "rubric_path": str(mismatched_rubric_path),
+        },
+    ]
+    rubric_results = [
+        {"slug": "env__aligned", "trial_dir": "/trial-1", "status": "ok", "reward": 0.8},
+        {"slug": "env__mismatched", "trial_dir": "/trial-2", "status": "ok", "reward": 0.0},
+    ]
+    guidance_results = [
+        {"slug": "env__aligned", "trial_dir": "/trial-1", "status": "ok", "reward": 0.8, "info_path": str(info_path)},
+        {
+            "slug": "env__mismatched",
+            "trial_dir": "/trial-2",
+            "status": "ok",
+            "reward": 0.8,
+            "info_path": str(info_path),
+        },
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    rows_by_slug = {row["slug"]: row for row in rows}
+    summary = module.summarize(rows)
+
+    assert rows_by_slug["env__aligned"]["potential_rubric_task_mismatch"] is False
+    assert rows_by_slug["env__aligned"]["rubric_task_vocab_coverage"] >= 0.5
+    assert rows_by_slug["env__mismatched"]["potential_rubric_task_mismatch"] is True
+    assert rows_by_slug["env__mismatched"]["rubric_task_vocab_coverage"] < 0.5
+    assert summary["by_split"]["eval"]["pct_potential_rubric_task_mismatch"] == 0.5
+
+
+def test_analyze_guidance_eval_flags_rubric_language_in_guidance_output(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text("Grade the workbook using score bands.")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "The workbook is mixed.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/report.xlsx.",
+                    "Trajectory check: inspected tool calls.",
+                    "Score calibration/cap audit: the rubric requires a maximum score allowed of 0.70.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__rubric_language",
+            "trial_dir": "/trial",
+            "split": "eval",
+            "judge_guidance_path": str(guidance_path),
+        }
+    ]
+    rubric_results = [{"slug": "env__rubric_language", "trial_dir": "/trial", "status": "ok", "reward": 0.5}]
+    guidance_results = [
+        {
+            "slug": "env__rubric_language",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.5,
+            "info_path": str(info_path),
+        }
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["mentions_rubric_language"] is True
+    assert summary["by_split"]["eval"]["pct_mentions_rubric_language"] == 1.0
+
+
+def test_analyze_guidance_eval_flags_source_guidance_conflicts(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text("Grade category totals against expected golden figures.")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "The workbook follows the source but misses the stated checkpoint.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/report.xlsx.",
+                    "Source verification audit: the captured COGS tracker recomputed to Handbags 104, matching the workbook but not the guidance's stated expected category distribution.",
+                    "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__source_guidance_conflict",
+            "trial_dir": "/trial",
+            "split": "eval",
+            "judge_guidance_path": str(guidance_path),
+        }
+    ]
+    rubric_results = [{"slug": "env__source_guidance_conflict", "trial_dir": "/trial", "status": "ok", "reward": 0.5}]
+    guidance_results = [
+        {
+            "slug": "env__source_guidance_conflict",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.5,
+            "info_path": str(info_path),
+        }
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["mentions_source_guidance_conflict"] is True
+    assert summary["by_split"]["eval"]["pct_mentions_source_guidance_conflict"] == 1.0
+
+
+def test_analyze_guidance_eval_flags_formula_cache_source_audits(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text("Grade finance workbook actuals using displayed book-of-record values.")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "The workbook recomputed unposted finance lines.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/report.xlsx.",
+                    "Formula cache/source-value audit: source finance workbook cells I3:I12 contain formulas without cached values, so they should remain blank posted actuals.",
+                    "Score calibration/cap audit: strictest applicable cap is 0.50.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__formula_cache",
+            "trial_dir": "/trial",
+            "split": "eval",
+            "judge_guidance_path": str(guidance_path),
+        }
+    ]
+    rubric_results = [{"slug": "env__formula_cache", "trial_dir": "/trial", "status": "ok", "reward": 0.5}]
+    guidance_results = [
+        {
+            "slug": "env__formula_cache",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.5,
+            "info_path": str(info_path),
+        }
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["mentions_formula_cache_source_audit"] is True
+    assert summary["by_split"]["eval"]["pct_mentions_formula_cache_source_audit"] == 1.0
+
+
+def test_analyze_guidance_eval_does_not_overcredit_source_and_command_evidence(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text("Grade the final deliverable and trajectory evidence.")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "The result was partially checked.",
+                "evidence": [
+                    "Read source data at /workspace/data/orders.csv.",
+                    "Ran a command that printed workbook sheet names.",
+                    "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__source_only",
+            "trial_dir": "/trial",
+            "split": "eval",
+            "judge_guidance_path": str(guidance_path),
+        }
+    ]
+    rubric_results = [{"slug": "env__source_only", "trial_dir": "/trial", "status": "ok", "reward": 0.5}]
+    guidance_results = [
+        {
+            "slug": "env__source_only",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.5,
+            "info_path": str(info_path),
+        }
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+
+    assert rows[0]["has_file_or_path_evidence"] is False
+    assert rows[0]["mentions_trajectory_or_tools"] is False
+
+
+def test_analyze_guidance_eval_tracks_source_availability_audits(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    instruction_path = tmp_path / "instruction.md"
+    instruction_path.write_text("Use Shopify and QuickBooks where files clearly support the interpretation.")
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text("Expected sources include Shopify/orders.xlsx and QuickBooks/bills.csv.")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "The result checked available sources.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/deliverables/report.xlsx.",
+                    "Source availability audit: Shopify exports were missing; QuickBooks bills.csv was accessible.",
+                    "Inspected trajectory file: final command succeeded.",
+                    "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                ],
+            }
+        )
+    )
+    info_path_without_source_audit = tmp_path / "guidance_info_without_source_audit.json"
+    info_path_without_source_audit.write_text(
+        json.dumps(
+            {
+                "reasoning": "The result checked sources but did not audit availability.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/deliverables/report.xlsx.",
+                    "Inspected trajectory file: final command succeeded.",
+                    "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__with_source_audit",
+            "trial_dir": "/trial-1",
+            "split": "eval",
+            "instruction_path": str(instruction_path),
+            "judge_guidance_path": str(guidance_path),
+        },
+        {
+            "slug": "env__without_source_audit",
+            "trial_dir": "/trial-2",
+            "split": "eval",
+            "instruction_path": str(instruction_path),
+            "judge_guidance_path": str(guidance_path),
+        },
+    ]
+    rubric_results = [
+        {"slug": "env__with_source_audit", "trial_dir": "/trial-1", "status": "ok", "reward": 0.5},
+        {"slug": "env__without_source_audit", "trial_dir": "/trial-2", "status": "ok", "reward": 0.5},
+    ]
+    guidance_results = [
+        {
+            "slug": "env__with_source_audit",
+            "trial_dir": "/trial-1",
+            "status": "ok",
+            "reward": 0.5,
+            "info_path": str(info_path),
+        },
+        {
+            "slug": "env__without_source_audit",
+            "trial_dir": "/trial-2",
+            "status": "ok",
+            "reward": 0.5,
+            "info_path": str(info_path_without_source_audit),
+        },
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["requires_source_availability_check"] is True
+    assert rows[0]["mentions_source_availability_audit"] is True
+    assert rows[1]["requires_source_availability_check"] is True
+    assert rows[1]["mentions_source_availability_audit"] is False
+    assert rows[0]["required_audit_coverage"] == 1.0
+    assert rows[1]["required_audit_coverage"] < rows[0]["required_audit_coverage"]
+    assert rows[1]["evidence_quality"] < rows[0]["evidence_quality"]
+    assert summary["by_split"]["eval"]["pct_requires_source_availability_check"] == 1.0
+    assert summary["by_split"]["eval"]["pct_mentions_source_availability_audit"] == 0.5
+    assert summary["by_split"]["eval"]["pct_mentions_source_availability_audit_when_required"] == 0.5
+    assert summary["by_split"]["eval"]["mean_required_audit_coverage"] < 1.0
+
+
+def test_analyze_guidance_eval_tracks_source_verification_audits(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    instruction_path = tmp_path / "instruction.md"
+    instruction_path.write_text("Prepare exact revenue calculations in a workbook.")
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text("Verification requirement: independently verify numerical claims against source files.")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "The result checked source-backed numbers.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/deliverables/report.xlsx.",
+                    "Source availability audit: source.csv was available in the workspace.",
+                    "Source verification audit: recomputed revenue totals from source.csv and compared them to report.xlsx.",
+                    "Inspected trajectory file: final command succeeded.",
+                    "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                ],
+            }
+        )
+    )
+    info_path_without_source_verification = tmp_path / "guidance_info_without_source_verification.json"
+    info_path_without_source_verification.write_text(
+        json.dumps(
+            {
+                "reasoning": "The result checked the workbook but did not independently verify the source numbers.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/deliverables/report.xlsx.",
+                    "Source availability audit: source.csv was available in the workspace.",
+                    "Inspected trajectory file: final command succeeded.",
+                    "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__with_source_verification",
+            "trial_dir": "/trial-1",
+            "split": "eval",
+            "instruction_path": str(instruction_path),
+            "judge_guidance_path": str(guidance_path),
+        },
+        {
+            "slug": "env__without_source_verification",
+            "trial_dir": "/trial-2",
+            "split": "eval",
+            "instruction_path": str(instruction_path),
+            "judge_guidance_path": str(guidance_path),
+        },
+    ]
+    rubric_results = [
+        {"slug": "env__with_source_verification", "trial_dir": "/trial-1", "status": "ok", "reward": 0.5},
+        {"slug": "env__without_source_verification", "trial_dir": "/trial-2", "status": "ok", "reward": 0.5},
+    ]
+    guidance_results = [
+        {
+            "slug": "env__with_source_verification",
+            "trial_dir": "/trial-1",
+            "status": "ok",
+            "reward": 0.5,
+            "info_path": str(info_path),
+        },
+        {
+            "slug": "env__without_source_verification",
+            "trial_dir": "/trial-2",
+            "status": "ok",
+            "reward": 0.5,
+            "info_path": str(info_path_without_source_verification),
+        },
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["requires_source_verification_check"] is True
+    assert rows[0]["mentions_source_verification_audit"] is True
+    assert rows[1]["requires_source_verification_check"] is True
+    assert rows[1]["mentions_source_verification_audit"] is False
+    assert rows[0]["required_audit_coverage"] == 1.0
+    assert rows[1]["required_audit_coverage"] < rows[0]["required_audit_coverage"]
+    assert rows[1]["evidence_quality"] < rows[0]["evidence_quality"]
+    assert summary["by_split"]["eval"]["pct_requires_source_verification_check"] == 1.0
+    assert summary["by_split"]["eval"]["pct_mentions_source_verification_audit"] == 0.5
+    assert summary["by_split"]["eval"]["pct_mentions_source_verification_audit_when_required"] == 0.5
+    assert summary["by_split"]["eval"]["mean_required_audit_coverage"] < 1.0
+
+
+def test_analyze_guidance_eval_tracks_declared_score_ceiling_violations(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text("Grade using score caps and verified artifacts.")
+    over_cap_info_path = tmp_path / "over_cap_info.json"
+    over_cap_info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "The result exceeds its own cap.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/report.md.",
+                    "Inspected trajectory file: final command succeeded.",
+                    "Score calibration/cap audit: the strictest applicable cap is 0.60.",
+                ],
+            }
+        )
+    )
+    within_cap_info_path = tmp_path / "within_cap_info.json"
+    within_cap_info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "The result stays inside its cap.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/report.md.",
+                    "Inspected trajectory file: final command succeeded.",
+                    "Score calibration/cap audit: the strictest applicable cap is 0.60.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__over_cap",
+            "trial_dir": "/trial-1",
+            "split": "eval",
+            "judge_guidance_path": str(guidance_path),
+        },
+        {
+            "slug": "env__within_cap",
+            "trial_dir": "/trial-2",
+            "split": "eval",
+            "judge_guidance_path": str(guidance_path),
+        },
+    ]
+    rubric_results = [
+        {"slug": "env__over_cap", "trial_dir": "/trial-1", "status": "ok", "reward": 0.5},
+        {"slug": "env__within_cap", "trial_dir": "/trial-2", "status": "ok", "reward": 0.5},
+    ]
+    guidance_results = [
+        {
+            "slug": "env__over_cap",
+            "trial_dir": "/trial-1",
+            "status": "ok",
+            "reward": 0.75,
+            "info_path": str(over_cap_info_path),
+        },
+        {
+            "slug": "env__within_cap",
+            "trial_dir": "/trial-2",
+            "status": "ok",
+            "reward": 0.55,
+            "info_path": str(within_cap_info_path),
+        },
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["declared_score_ceiling"] == 0.6
+    assert rows[0]["guidance_exceeds_declared_score_ceiling"] is True
+    assert rows[1]["declared_score_ceiling"] == 0.6
+    assert rows[1]["guidance_exceeds_declared_score_ceiling"] is False
+    assert summary["by_split"]["eval"]["pct_has_declared_score_ceiling"] == 1.0
+    assert summary["by_split"]["eval"]["pct_guidance_exceeds_declared_score_ceiling"] == 0.5
+
+
+def test_analyze_guidance_eval_flags_near_ceiling_foundational_failures(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text("Grade central forecast math and required external verification.")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": (
+                    "The central quantitative output is materially wrong, and the agent missed a required "
+                    "external verification, but the artifact exists."
+                ),
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/email_draft.txt.",
+                    "Inspected trajectory file: found a draft creation call.",
+                    "Score calibration/cap audit: because foundational requirement failures remain, the maximum score allowed is 0.60.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__near_ceiling_foundational_failure",
+            "trial_dir": "/trial",
+            "split": "eval",
+            "judge_guidance_path": str(guidance_path),
+        }
+    ]
+    rubric_results = [
+        {
+            "slug": "env__near_ceiling_foundational_failure",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.3,
+        }
+    ]
+    guidance_results = [
+        {
+            "slug": "env__near_ceiling_foundational_failure",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.56,
+            "info_path": str(info_path),
+        }
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["near_declared_ceiling_with_foundational_failure"] is True
+    assert summary["by_split"]["eval"]["pct_near_declared_ceiling_with_foundational_failure"] == 1.0
+
+
+def test_analyze_guidance_eval_ignores_low_ceiling_foundational_failures(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text("Grade central forecast math and required external verification.")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "The central quantitative output is materially wrong.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/email_draft.txt.",
+                    "Inspected trajectory file: found a draft creation call.",
+                    "Score calibration/cap audit: the maximum score allowed is 0.45.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__low_ceiling_foundational_failure",
+            "trial_dir": "/trial",
+            "split": "eval",
+            "judge_guidance_path": str(guidance_path),
+        }
+    ]
+    rubric_results = [
+        {
+            "slug": "env__low_ceiling_foundational_failure",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.3,
+        }
+    ]
+    guidance_results = [
+        {
+            "slug": "env__low_ceiling_foundational_failure",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.42,
+            "info_path": str(info_path),
+        }
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["near_declared_ceiling_with_foundational_failure"] is False
+    assert summary["by_split"]["eval"]["pct_near_declared_ceiling_with_foundational_failure"] == 0.0
+
+
+def test_analyze_guidance_eval_flags_near_ceiling_missing_required_artifacts(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text("Grade the required workbook and written-summary deliverables.")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": (
+                    "The response did not produce the required Excel workbook or separate written-summary "
+                    "artifact, but it used the source data well."
+                ),
+                "evidence": [
+                    (
+                        "Workspace/artifact check: found source files but no generated deliverable workbook, "
+                        "markdown/text/doc/pdf summary, or output directory."
+                    ),
+                    "Inspected trajectory file: the final step contains only a textual answer.",
+                    (
+                        "Score calibration/cap audit: no Excel workbook/separate summary artifacts cap the "
+                        "maximum score allowed at 0.60."
+                    ),
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__near_ceiling_missing_artifacts",
+            "trial_dir": "/trial",
+            "split": "eval",
+            "judge_guidance_path": str(guidance_path),
+        }
+    ]
+    rubric_results = [
+        {
+            "slug": "env__near_ceiling_missing_artifacts",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.3,
+        }
+    ]
+    guidance_results = [
+        {
+            "slug": "env__near_ceiling_missing_artifacts",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.58,
+            "info_path": str(info_path),
+        }
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["near_declared_ceiling_with_foundational_failure"] is True
+    assert summary["by_split"]["eval"]["pct_near_declared_ceiling_with_foundational_failure"] == 1.0
+
+
+def test_analyze_guidance_eval_flags_high_foundational_failure_scores_without_justification(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    guidance_path = tmp_path / "judge_guidance.md"
+    guidance_path.write_text("Grade source-grounded workbook analysis.")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": (
+                    "The central sales methodology is materially wrong, and multiple central quantitative "
+                    "requirements fail despite a useful workbook."
+                ),
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/deliverables/review.xlsx.",
+                    "Inspected trajectory file: workbook creation command was present.",
+                    "Score calibration/cap audit: the wrong revenue basis makes the maximum score allowed 0.65.",
+                ],
+            }
+        )
+    )
+    manifest = [
+        {
+            "slug": "env__high_foundational_failure_score",
+            "trial_dir": "/trial",
+            "split": "eval",
+            "judge_guidance_path": str(guidance_path),
+        }
+    ]
+    rubric_results = [
+        {
+            "slug": "env__high_foundational_failure_score",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.3,
+        }
+    ]
+    guidance_results = [
+        {
+            "slug": "env__high_foundational_failure_score",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.58,
+            "info_path": str(info_path),
+        }
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["near_declared_ceiling_with_foundational_failure"] is True
+    assert summary["by_split"]["eval"]["pct_near_declared_ceiling_with_foundational_failure"] == 1.0
+
+
+def test_analyze_guidance_eval_tracks_guidance_retry_and_usage_metrics(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    info_path = tmp_path / "guidance_info.json"
+    info_path.write_text(
+        json.dumps(
+            {
+                "reasoning": "The deliverable mostly matches the task.",
+                "evidence": [
+                    "Workspace/artifact check: read /workspace/report.xlsx.",
+                    "Inspected trajectory file: command output supports the score.",
+                    "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                ],
+                "llm_usage": {
+                    "cost_usd": 1.23456,
+                    "prompt_tokens": 1000,
+                    "completion_tokens": 20,
+                    "cache_read_tokens": 900,
+                },
+            }
+        )
+    )
+    eval_dir = tmp_path / "guidance_eval"
+    eval_dir.mkdir()
+    (eval_dir / "stdout.txt").write_text(
+        "[retry 1/2] Retrying guidance score after invalid judge output\n"
+        "[retry 2/2] Retrying guidance score after invalid judge output\n"
+    )
+    manifest = [
+        {
+            "slug": "env__tracked_guidance_run",
+            "trial_dir": "/trial",
+            "split": "eval",
+            "judge_guidance_path": str(tmp_path / "judge_guidance.md"),
+        }
+    ]
+    rubric_results = [{"slug": "env__tracked_guidance_run", "trial_dir": "/trial", "status": "ok", "reward": 0.7}]
+    guidance_results = [
+        {
+            "slug": "env__tracked_guidance_run",
+            "trial_dir": "/trial",
+            "status": "ok",
+            "reward": 0.75,
+            "info_path": str(info_path),
+            "eval_dir": str(eval_dir),
+        }
+    ]
+
+    rows = module.joined_rows(manifest, rubric_results, guidance_results)
+    summary = module.summarize(rows)
+
+    assert rows[0]["guidance_retry_count"] == 2
+    assert rows[0]["guidance_retried"] is True
+    assert rows[0]["guidance_llm_cost_usd"] == 1.2346
+    assert rows[0]["guidance_prompt_tokens"] == 1000
+    assert rows[0]["guidance_completion_tokens"] == 20
+    assert rows[0]["guidance_cache_read_tokens"] == 900
+    assert summary["by_split"]["eval"]["mean_guidance_retry_count"] == 2.0
+    assert summary["by_split"]["eval"]["pct_guidance_retried"] == 1.0
+    assert summary["by_split"]["eval"]["total_guidance_llm_cost_usd"] == 1.2346
+    assert summary["by_split"]["eval"]["mean_guidance_llm_cost_usd"] == 1.2346
+
+
+def test_analyze_guidance_eval_summarizes_failed_guidance_runs(tmp_path: pathlib.Path) -> None:
+    module = load_script_module("analyze_guidance_eval")
+    ok_info_path = tmp_path / "ok_info.json"
+    ok_info_path.write_text(json.dumps({"llm_usage": {"cost_usd": 0.25, "prompt_tokens": 100}}))
+    failed_info_path = tmp_path / "failed_info.json"
+    failed_info_path.write_text(json.dumps({"llm_usage": {"cost_usd": 0.75, "prompt_tokens": 300}}))
+    ok_eval_dir = tmp_path / "ok_eval"
+    ok_eval_dir.mkdir()
+    (ok_eval_dir / "stdout.txt").write_text("[guidance] Evaluating holistic score\n")
+    failed_eval_dir = tmp_path / "failed_eval"
+    failed_eval_dir.mkdir()
+    (failed_eval_dir / "stdout.txt").write_text(
+        "[guidance] Evaluating holistic score\n[retry 1/2] Retrying guidance score...\n"
+    )
+    rows = [
+        {
+            "slug": "env__ok",
+            "split": "eval",
+            "guidance_reward": 0.8,
+            "rubric_reward": 0.75,
+            "abs_diff": 0.05,
+            "signed_diff": 0.05,
+            "evidence_quality": 1.0,
+            "required_audit_coverage": 1.0,
+            "guidance_vocab_coverage": 0.2,
+            "guidance_retry_count": 0,
+            "guidance_retried": False,
+            "guidance_llm_cost_usd": 0.25,
+            "guidance_prompt_tokens": 100,
+            "guidance_completion_tokens": 0,
+            "guidance_cache_read_tokens": 0,
+            "declared_score_ceiling": 1.0,
+            "guidance_exceeds_declared_score_ceiling": False,
+            "near_declared_ceiling_with_foundational_failure": False,
+            "has_file_or_path_evidence": True,
+            "mentions_trajectory_or_tools": True,
+            "mentions_score_calibration_cap_audit": True,
+            "mentions_rubric_language": False,
+            "mentions_source_guidance_conflict": False,
+            "mentions_formula_cache_source_audit": False,
+            "mentions_output_location_conflict_audit": False,
+            "mentions_action_side_effect_audit": False,
+            "mentions_source_availability_audit": False,
+            "mentions_source_verification_audit": False,
+            "mentions_action_or_side_effects": False,
+            "requires_action_or_side_effect_check": False,
+            "requires_output_location_conflict_check": False,
+            "requires_source_availability_check": False,
+            "requires_source_verification_check": False,
+            "potential_rubric_task_mismatch": False,
+        }
+    ]
+    guidance_results = [
+        {
+            "slug": "env__ok",
+            "trial_dir": "/ok",
+            "status": "ok",
+            "reward": 0.8,
+            "info_path": str(ok_info_path),
+            "eval_dir": str(ok_eval_dir),
+        },
+        {
+            "slug": "env__failed",
+            "trial_dir": "/failed",
+            "status": "failed",
+            "info_path": str(failed_info_path),
+            "eval_dir": str(failed_eval_dir),
+        },
+    ]
+
+    summary = module.summarize(rows, guidance_results=guidance_results)
+
+    assert summary["guidance_runs"]["n"] == 2
+    assert summary["guidance_runs"]["status_counts"] == {"failed": 1, "ok": 1}
+    assert summary["guidance_runs"]["failed_count"] == 1
+    assert summary["guidance_runs"]["missing_reward_count"] == 1
+    assert summary["guidance_runs"]["failure_rate"] == 0.5
+    assert summary["guidance_runs"]["mean_guidance_retry_count"] == 0.5
+    assert summary["guidance_runs"]["pct_guidance_retried"] == 0.5
+    assert summary["guidance_runs"]["total_guidance_llm_cost_usd"] == 1.0
+    assert summary["guidance_runs"]["mean_guidance_prompt_tokens"] == 200.0
+
+
+def test_eval_guidance_scores_defaults_to_openai_when_env_file_has_only_openai_key(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_script_module("eval_guidance_scores")
+    for key in [
+        "ANTHROPIC_API_KEY",
+        "GANDALF_EVAL_MODEL",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "LLM_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    env_file = tmp_path / "env"
+    env_file.write_text("OPENAI_API_KEY=fake-openai-key\n")
+
+    env = module.build_grader_env(env_file)
+    model = module.choose_default_model(env)
+    module.set_llm_api_key_for_model(env, model)
+
+    assert model == "openai/gpt-5.5"
+    assert env["LLM_API_KEY"] == "fake-openai-key"
+
+
+def test_eval_guidance_scores_does_not_use_openai_key_for_explicit_gemini_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_script_module("eval_guidance_scores")
+    for key in [
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "LLM_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    env = {"OPENAI_API_KEY": "fake-openai-key"}
+
+    module.set_llm_api_key_for_model(env, "gemini/gemini-2.5-flash")
+
+    assert "LLM_API_KEY" not in env

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -9,15 +9,34 @@ from unittest.mock import patch
 
 import pytest
 
+from gandalf.guidance_evidence import (
+    extract_score_calibration_ceiling,
+    has_above_midpoint_justification,
+    has_action_side_effect_audit,
+    has_foundational_failure_language,
+    has_output_location_conflict_audit,
+    has_score_calibration_audit,
+    has_source_availability_audit,
+    has_source_guidance_conflict_audit,
+    has_source_guidance_conflict_language,
+    has_source_verification_audit,
+    requires_action_side_effect_audit,
+    requires_output_location_conflict_audit,
+    requires_source_availability_audit,
+    requires_source_verification_audit,
+)
 from gandalf.judge import (
     build_batch_judge_prompt,
+    build_guidance_judge_prompt,
     build_judge_prompt,
     make_verdict_path,
     mcp_server_to_config,
     read_batch_verdict,
+    read_guidance_score,
     read_verdict,
     run_judge,
     run_judge_batch,
+    run_judge_guidance,
 )
 from gandalf.models import LLMUsage, MCPServer
 from tests.conftest import MOCK_USAGE
@@ -116,6 +135,423 @@ class TestBuildJudgePrompt:
         output_idx = prompt.index("OUTPUT")
         crit_idx = prompt.index("CRIT")
         assert preamble_idx < guidance_idx < instr_idx < output_idx < crit_idx
+
+
+class TestBuildGuidanceJudgePrompt:
+    def test_contains_guidance_context_paths_and_score_path(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Build a workbook",
+            final_output="Done!",
+            judge_guidance="Score formulas and final state.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        assert "Build a workbook" in prompt
+        assert "Done!" in prompt
+        assert "Score formulas and final state." in prompt
+        assert "/workspace/gandalf_trajectory.json" in prompt
+        assert "/workspace/guidance_score.json" in prompt
+        assert '"score"' in prompt
+        assert '"reasoning"' in prompt
+        assert '"evidence"' in prompt
+
+    def test_instructs_judge_to_balance_artifact_and_trajectory_evidence(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Build a workbook",
+            final_output="Done!",
+            judge_guidance="Grade formulas, source data, and email actions.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "derive a short checklist" in lowered
+        assert "workspace/artifact" in lowered
+        assert "trajectory" in lowered
+        assert "source-grounded" in lowered
+        assert "positive and negative" in lowered
+
+    def test_instructs_judge_to_apply_guidance_score_caps(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Build a workbook",
+            final_output="Done!",
+            judge_guidance="Hard penalty: fabricated data caps the score at 0.5.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "score bands" in lowered
+        assert "hard penalties" in lowered
+        assert "strictest applicable cap" in lowered
+        assert "do not exceed that cap" in lowered
+
+    def test_instructs_judge_to_place_scores_lower_in_band_for_foundational_failures(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Compute the core forecast and confirm or correct a hypothesis.",
+            final_output="Done!",
+            judge_guidance="0.4-0.6 gets the structure right but misses key analytical requirements.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "do not default to the top of an applicable band" in lowered
+        assert "foundational calculation" in lowered
+        assert "downstream dependent outputs" in lowered
+        assert "explicit confirm/correct" in lowered
+        assert "reserve scores near the top of a band" in lowered
+
+    def test_instructs_judge_to_use_guidance_not_rubric_terminology(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Grade the final workbook.",
+            final_output="Done!",
+            judge_guidance="Known failure mode: wrong source caps score at 0.7.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "this is guidance-mode grading" in lowered
+        assert "refer to these instructions as grading guidance" in lowered
+        assert "do not call them a rubric" in lowered
+
+    def test_instructs_judge_to_surface_source_guidance_conflicts(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Grade the category summary against source data.",
+            final_output="Done!",
+            judge_guidance="Expected category totals are listed below.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "source/guidance conflict audit" in lowered
+        assert "accessible source data conflicts" in lowered
+        assert "do not silently penalize source-grounded work" in lowered
+        assert "explain which source you treated as authoritative" in lowered
+
+    def test_instructs_judge_to_distinguish_uncached_source_formulas_from_posted_values(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Use the finance workbook as the book of record.",
+            final_output="Done!",
+            judge_guidance="Blank finance-book actuals should remain blank.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "formula cache/source-value audit" in lowered
+        assert "formulas without cached values" in lowered
+        assert "do not recompute source-workbook formulas" in lowered
+        assert "posted or displayed book-of-record actuals" in lowered
+
+    def test_instructs_judge_to_write_explicit_cap_audit(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Build a workbook",
+            final_output="Done!",
+            judge_guidance="Fabricated expiration dates cap the score at 0.50.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "score calibration/cap audit" in lowered
+        assert "maximum score allowed" in lowered
+        assert "concrete numeric maximum" in lowered
+        assert "avoid vague maximums" in lowered
+        assert "if a plausible cap or hard penalty is not applied" in lowered
+        assert "explain why it does not apply" in lowered
+
+    def test_instructs_judge_to_place_scores_below_caps_for_foundational_failures(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Create an email with a demand forecast and verify the staffing hypothesis.",
+            final_output="Done!",
+            judge_guidance="0.4-0.6 has structure with notable gaps. 0.6-0.8 requires accurate numbers.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "near a declared ceiling" in lowered
+        assert "foundational requirement failures" in lowered
+        assert "central quantitative output" in lowered
+        assert "required external verification" in lowered
+        assert "minor, non-core issues remain" in lowered
+        assert "top quarter of a band" in lowered
+        assert "requirements for the next higher band" in lowered
+        assert "move the score to the middle or lower part" in lowered
+        assert "numeric score must match that placement word" in lowered
+        assert "do not call a score middle-of-band" in lowered
+        assert "compute the midpoint" in lowered
+        assert "at or below that midpoint" in lowered
+        assert "missing required deliverables or artifacts" in lowered
+
+    def test_instructs_judge_to_put_above_midpoint_justification_in_cap_audit(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Create an email with a demand forecast and verify the staffing hypothesis.",
+            final_output="Done!",
+            judge_guidance="0.4-0.6 has structure with notable gaps. 0.6-0.8 requires accurate numbers.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "if you choose a score above the midpoint" in lowered
+        assert "score calibration/cap audit" in lowered
+        assert "above the midpoint" in lowered
+        assert "because" in lowered
+        assert "central requirements" in lowered
+
+    def test_instructs_judge_to_reconcile_instruction_guidance_conflicts(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Save the workbook to /home/agent/workspace/deliverables.",
+            final_output="Done!",
+            judge_guidance="Required artifact: workbook in /tmp/output.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "task instructions are the primary user-facing contract" in lowered
+        assert "if the task instructions and grading guidance conflict" in lowered
+        assert "output location" in lowered
+        assert "do not penalize" in lowered
+        assert "task-instructed" in lowered
+        assert "before applying any output-location penalty" in lowered
+        assert "output-location conflict audit" in lowered
+
+    def test_instructs_judge_to_audit_actions_and_side_effects(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Create a report. Do not send email or create calendar events.",
+            final_output="Done!",
+            judge_guidance="No emails or calendar events should be created.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "action/side-effect audit" in lowered
+        assert "required or forbidden external actions" in lowered
+        assert "email drafts/sends" in lowered
+        assert "calendar events" in lowered
+        assert "trajectory" in lowered
+        assert "your evidence must include" in lowered
+        assert 'one "action/side-effect audit" evidence item' in lowered
+
+    def test_instructs_judge_not_to_count_file_imitation_as_external_action(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Draft an Outlook email to billing@example.com. Save it as a draft; do not send.",
+            final_output="I saved draft_email.eml in deliverables.",
+            judge_guidance="Required output: an Outlook draft addressed to billing@example.com.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "file imitation" in lowered
+        assert "does not by itself prove" in lowered
+        assert "live external artifact" in lowered
+        assert "outlook draft" in lowered
+
+    def test_instructs_judge_to_audit_source_availability_before_penalizing_missing_context(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Use Shopify and QuickBooks only where the files clearly support the interpretation.",
+            final_output="The Shopify and QuickBooks folders were empty, so I used the financial summary.",
+            judge_guidance="Expected sources include Shopify/orders.xlsx and QuickBooks/bills.csv.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "source availability audit" in lowered
+        assert "accessible to you" in lowered
+        assert "not accessible" in lowered
+        assert "ignored an accessible source" in lowered
+        assert "always include" in lowered
+        assert "whether expected sources are available or missing" in lowered
+
+    def test_instructs_judge_not_to_hard_cap_for_inaccessible_supporting_sources(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions=(
+                "Build the forecast from the annual plan. Use Shopify and QuickBooks only as supporting context "
+                "where files clearly support the interpretation."
+            ),
+            final_output="The Shopify and QuickBooks folders were empty, so I used available source files.",
+            judge_guidance="Expected sources include Shopify/orders.xlsx and QuickBooks/bills.csv.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "do not apply a missing-source cap" in lowered
+        assert "inaccessible supporting source" in lowered
+        assert "reasonable source search" in lowered
+        assert "ignored an accessible source" in lowered
+
+    def test_instructs_judge_to_audit_independent_source_verification(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Prepare exact revenue calculations.",
+            final_output="Done.",
+            judge_guidance="Verification requirement: independently verify numerical claims against source files.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert "source verification audit" in lowered
+        assert "independent verification" in lowered
+        assert "recomputed" in lowered
+
+    def test_instructs_judge_that_required_source_verification_must_be_evidence_item(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Prepare exact revenue calculations.",
+            final_output="Done.",
+            judge_guidance="Use the accompanying bronze deliverable as the source of truth for exact figures.",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+        lowered = prompt.lower()
+        assert 'your evidence must include one "source verification audit" evidence item' in lowered
+        assert "source-of-truth" in lowered
+
+    def test_guidance_prompt_surfaces_mandatory_evidence_checklist(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Prepare exact revenue calculations and create an Outlook draft; do not send it.",
+            final_output="Done.",
+            judge_guidance=(
+                "Expected sources include Shopify/orders.json and QuickBooks/bills.csv. "
+                "Independently verify numerical claims against source files."
+            ),
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/guidance_score.json",
+        )
+
+        lowered = prompt.lower()
+
+        assert "mandatory evidence checklist" in lowered
+        assert "use these exact evidence labels" in lowered
+        assert '"source availability audit"' in lowered
+        assert '"source verification audit"' in lowered
+        assert '"action/side-effect audit"' in lowered
+        assert '"score calibration/cap audit"' in lowered
+        assert "do not rename these audit labels" in lowered
+
+    def test_instructs_judge_to_use_trajectory_file_not_inlined_json(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="x",
+            final_output="z",
+            judge_guidance="g",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            score_path="/workspace/score.json",
+        )
+        assert "<trajectory_file>" in prompt
+        assert "inspect" in prompt.lower()
+        assert "/workspace/gandalf_trajectory.json" in prompt
+        assert '"steps"' not in prompt
+
+    def test_instructs_judge_to_use_cloned_workspace_path_for_artifacts(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Save the workbook to /home/agent/workspace/deliverables/report.xlsx.",
+            final_output="Done.",
+            judge_guidance="Grade the saved workbook.",
+            trajectory_path="/tmp/judge_workspace_abc/gandalf_trajectory.json",
+            score_path="/tmp/judge_workspace_abc/guidance_score.json",
+            workspace_path="/tmp/judge_workspace_abc",
+        )
+        lowered = prompt.lower()
+        assert "<workspace_path>" in prompt
+        assert "/tmp/judge_workspace_abc" in prompt
+        assert "cloned judge workspace" in lowered
+        assert "relative to this workspace path" in lowered
+        assert "original container paths" in lowered
+        assert "/home/agent/workspace/deliverables" in prompt
+        assert "workspace_path/deliverables" in lowered
+
+    def test_instructs_judge_to_inventory_cloned_workspace_before_original_paths(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Save the workbook to /home/agent/workspace/deliverables/report.xlsx.",
+            final_output="Done.",
+            judge_guidance="Required artifact: workbook in /tmp/output.",
+            trajectory_path="/tmp/judge_workspace_abc/gandalf_trajectory.json",
+            score_path="/tmp/judge_workspace_abc/guidance_score.json",
+            workspace_path="/tmp/judge_workspace_abc",
+        )
+        lowered = prompt.lower()
+        assert "first inventory the cloned workspace path" in lowered
+        assert "before checking original absolute paths" in lowered
+        assert 'find "$workspace_path"' in lowered
+        assert "do not declare an artifact missing or inaccessible" in lowered
+
+    def test_instructs_judge_to_classify_output_types_before_format_specific_checks(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Create a workbook and memo.",
+            final_output="Done.",
+            judge_guidance="Grade the workbook formulas and memo content.",
+            trajectory_path="/tmp/judge_workspace_abc/gandalf_trajectory.json",
+            score_path="/tmp/judge_workspace_abc/guidance_score.json",
+            workspace_path="/tmp/judge_workspace_abc",
+        )
+        lowered = prompt.lower()
+        assert "classify the deliverable types" in lowered
+        assert "xlsx" in lowered
+        assert "docx" in lowered
+        assert "do not apply office-document-specific checks" in lowered
+
+    def test_instructs_judge_to_use_batched_bounded_artifact_inspection(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Create an Excel workbook.",
+            final_output="Done.",
+            judge_guidance="Check all variance formulas and source rows.",
+            trajectory_path="/tmp/judge_workspace_abc/gandalf_trajectory.json",
+            score_path="/tmp/judge_workspace_abc/guidance_score.json",
+            workspace_path="/tmp/judge_workspace_abc",
+        )
+        lowered = prompt.lower()
+        assert "batched" in lowered
+        assert "print findings or verdicts" in lowered
+        assert "do not dump whole workbooks" in lowered
+        assert "bounded" in lowered
+
+    def test_instructs_judge_to_use_rendered_and_formula_evidence_for_office_documents(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Create a spreadsheet and slide deck.",
+            final_output="Done.",
+            judge_guidance="Check formulas, charts, and layout.",
+            trajectory_path="/tmp/judge_workspace_abc/gandalf_trajectory.json",
+            score_path="/tmp/judge_workspace_abc/guidance_score.json",
+            workspace_path="/tmp/judge_workspace_abc",
+        )
+        lowered = prompt.lower()
+        assert "rendered screenshot" in lowered
+        assert "visual or layout" in lowered
+        assert "formula text" in lowered
+        assert "cached values" in lowered
+
+    def test_instructs_judge_to_apply_penalties_only_when_conditions_match(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Create a markdown summary and a CSV export.",
+            final_output="Done.",
+            judge_guidance="Penalty rules: apply X1 for spreadsheet formula errors and P1 for slide-master changes.",
+            trajectory_path="/tmp/judge_workspace_abc/gandalf_trajectory.json",
+            score_path="/tmp/judge_workspace_abc/guidance_score.json",
+            workspace_path="/tmp/judge_workspace_abc",
+        )
+        lowered = prompt.lower()
+        assert "only apply penalty rules when their stated conditions match" in lowered
+        assert "do not penalize choices the task explicitly requested" in lowered
+        assert "not a hypothetical ideal" in lowered
+
+    def test_instructs_judge_to_distinguish_reference_files_from_outputs(self) -> None:
+        prompt = build_guidance_judge_prompt(
+            instructions="Create a workbook using the provided input template.",
+            final_output="Done.",
+            judge_guidance="Compare against the golden workbook and source files.",
+            trajectory_path="/tmp/judge_workspace_abc/gandalf_trajectory.json",
+            score_path="/tmp/judge_workspace_abc/guidance_score.json",
+            workspace_path="/tmp/judge_workspace_abc",
+        )
+        lowered = prompt.lower()
+        assert "distinguish task inputs, source files, reference files, and golden files from agent outputs" in lowered
+        assert "reference or golden files are not agent-produced outputs" in lowered
+        assert "compare the output against them" in lowered
+
+    def test_custom_template_receives_guidance_variables(self) -> None:
+        template = "{{ instructions }}|{{ final_output }}|{{ judge_guidance }}|{{ trajectory_path }}|{{ score_path }}"
+        prompt = build_guidance_judge_prompt(
+            instructions="i",
+            final_output="o",
+            judge_guidance="g",
+            trajectory_path="/t.json",
+            score_path="/s.json",
+            judge_prompt=template,
+        )
+        assert prompt == "i|o|g|/t.json|/s.json"
 
 
 class TestMCPServerToConfig:
@@ -285,6 +721,1960 @@ class TestReadVerdict:
         assert "missing" in result.reasoning.lower()
 
 
+class TestReadGuidanceScore:
+    def test_valid_score(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+        result = read_guidance_score(str(p))
+        assert result.score == 0.75
+        assert result.reasoning == "Mostly correct."
+        assert result.evidence == [
+            "Workspace/artifact check: read /workspace/report.md.",
+            "Inspected trajectory file: final command succeeded.",
+            "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+        ]
+
+    def test_missing_workspace_artifact_evidence_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score is None
+        assert "workspace/artifact" in result.reasoning.lower()
+
+    def test_source_data_read_does_not_count_as_workspace_artifact_evidence(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Read source data at /workspace/data/orders.csv.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score is None
+        assert "workspace/artifact" in result.reasoning.lower()
+
+    def test_inaccessible_original_path_does_not_count_as_workspace_artifact_evidence(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Workspace/artifact check: in the current judge filesystem, /home/agent/workspace/deliverables and /workdir were not present, so I could not directly open the final XLSX from disk in this environment.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score is None
+        assert "workspace/artifact" in result.reasoning.lower()
+
+    def test_output_location_audit_does_not_replace_workspace_artifact_evidence(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Workspace/artifact check: in the current judge filesystem, /home/agent/workspace/deliverables and /workdir were not present, so I could not directly open the final XLSX from disk in this environment.",
+                        "Output-location conflict audit: trajectory step 42 created /home/agent/workspace/deliverables/report.xlsx, so I treated the task-instructed location as acceptable.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_output_location_conflict_audit=True)
+
+        assert result.score is None
+        assert "workspace/artifact" in result.reasoning.lower()
+
+    def test_concrete_missing_artifact_search_counts_as_workspace_artifact_evidence(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        evidence = [
+            "Workspace/artifact check: searched /tmp/judge_workspace_abc/deliverables and found no generated cost-estimate workbook or written summary file; only source files and logs were present.",
+            "Inspected trajectory file: final command succeeded.",
+            "Score calibration/cap audit: missing artifacts cap the score at 0.6.",
+        ]
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.54,
+                    "reasoning": "Analysis was partly correct but required artifacts are missing.",
+                    "evidence": evidence,
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score == 0.54
+        assert result.evidence == evidence
+
+    def test_missing_trajectory_evidence_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score is None
+        assert "trajectory" in result.reasoning.lower()
+
+    def test_command_output_does_not_count_as_trajectory_evidence(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Ran a command that printed workbook sheet names.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score is None
+        assert "trajectory" in result.reasoning.lower()
+
+    def test_inaccessible_trajectory_file_does_not_count_as_trajectory_evidence(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Trajectory check: gandalf_trajectory.json was not accessible in the judge workspace.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score is None
+        assert "trajectory" in result.reasoning.lower()
+
+    def test_missing_score_calibration_audit_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": ["Checked report.md"],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score is None
+        assert "score calibration/cap audit" in result.reasoning.lower()
+
+    def test_reports_multiple_validation_failures_at_once(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        evidence = ["Checked a generated report without concrete file, tool-use, source, or cap details."]
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": evidence,
+                }
+            )
+        )
+
+        result = read_guidance_score(
+            str(p),
+            require_source_availability_audit=True,
+            require_source_verification_audit=True,
+        )
+
+        lowered = result.reasoning.lower()
+        assert result.score is None
+        assert "score calibration/cap audit" in lowered
+        assert "workspace/artifact" in lowered
+        assert "trajectory" in lowered
+        assert "source availability audit" in lowered
+        assert "source verification audit" in lowered
+        assert result.evidence == evidence
+
+    def test_accepts_raw_connector_json_source_verification_when_required(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        evidence = [
+            "Workspace/artifact check: found deliverables/golden_spread_pricing_markdown_plan.xlsx plus pricing_markdown_brief.txt under the captured workspace deliverables directory.",
+            "Trajectory check: steps 12-51 show Shopify and Square connector exports and local workbook generation.",
+            "Source availability audit: accessible sources included raw API JSON dumps in deliverables/data for Shopify orders/inventory and Square orders/payments.",
+            "Source verification audit: from raw Shopify and Square JSON I recomputed latest paid non-cancelled Shopify order date as 2026-04-18 and latest completed Square sale date as 2026-04-19.",
+            "Score calibration/cap audit: required artifacts exist and maximum score allowed is 1.0.",
+        ]
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.66,
+                    "reasoning": "Substantial but incomplete task success.",
+                    "evidence": evidence,
+                }
+            )
+        )
+
+        result = read_guidance_score(
+            str(p),
+            require_source_availability_audit=True,
+            require_source_verification_audit=True,
+        )
+
+        assert result.score == 0.66
+        assert result.evidence == evidence
+
+    def test_weak_score_calibration_audit_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: reviewed the score.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score is None
+        assert "score calibration/cap audit" in result.reasoning.lower()
+
+    def test_vague_score_calibration_audit_rejection_asks_for_parseable_maximum(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.62,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: the strictest practical ceiling is about the mid-0.6s, so 0.62 is appropriate.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        lowered = result.reasoning.lower()
+        assert result.score is None
+        assert "score calibration/cap audit" in lowered
+        assert "parseable" in lowered
+        assert "concrete numeric maximum" in lowered
+
+    def test_bare_no_cap_score_calibration_audit_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score is None
+        assert "score calibration/cap audit" in result.reasoning.lower()
+
+    def test_score_above_declared_calibration_maximum_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.75,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: the strictest applicable cap is 0.60.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score is None
+        assert "exceeds" in result.reasoning.lower()
+        assert "0.6" in result.reasoning.lower()
+
+    def test_score_at_declared_calibration_maximum_is_valid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.6,
+                    "reasoning": "Mostly correct.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: the strictest applicable cap is 0.60.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score == 0.6
+
+    def test_near_ceiling_score_with_foundational_failures_needs_above_midpoint_justification(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.58,
+                    "reasoning": (
+                        "The central quantitative output is materially wrong and the required external "
+                        "verification was missed, but the artifact exists."
+                    ),
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/email_draft.txt.",
+                        "Inspected trajectory file: draft creation was present and no send action occurred.",
+                        "Score calibration/cap audit: foundational requirement failures remain, so the maximum score allowed is 0.60.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        lowered = result.reasoning.lower()
+        assert result.score is None
+        assert "near declared ceiling" in lowered
+        assert "foundational" in lowered
+        assert "above-midpoint" in lowered
+
+    def test_near_ceiling_score_with_foundational_failures_accepts_explicit_above_midpoint_justification(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.58,
+                    "reasoning": (
+                        "The central quantitative output is materially wrong, but all other central "
+                        "requirements were satisfied."
+                    ),
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/email_draft.txt.",
+                        "Inspected trajectory file: draft creation was present and no send action occurred.",
+                        (
+                            "Score calibration/cap audit: foundational requirement failures remain, so the "
+                            "maximum score allowed is 0.60. Above-midpoint justification: the required draft "
+                            "action, recipient envelope, all four content sections, supplier normalization, "
+                            "and actionable data-hygiene requirements were fully satisfied despite the "
+                            "central forecast miss."
+                        ),
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        assert result.score == 0.58
+
+    def test_near_ceiling_score_with_missing_required_artifacts_needs_above_midpoint_justification(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.58,
+                    "reasoning": (
+                        "The response did not produce the required Excel workbook or separate written-summary "
+                        "artifact, but it used the source data well."
+                    ),
+                    "evidence": [
+                        (
+                            "Workspace/artifact check: searched /workspace/deliverables and found no generated "
+                            "deliverable workbook, markdown/text/doc/pdf summary, or output directory."
+                        ),
+                        "Inspected trajectory file: the final step contains only a textual answer.",
+                        "Score calibration/cap audit: no Excel workbook/separate summary artifacts cap the maximum score allowed at 0.60.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        lowered = result.reasoning.lower()
+        assert result.score is None
+        assert "near declared ceiling" in lowered
+        assert "above-midpoint" in lowered
+
+    def test_high_score_with_foundational_failures_needs_above_midpoint_justification(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.58,
+                    "reasoning": (
+                        "The central Shopify sales methodology is materially wrong, and multiple central "
+                        "quantitative requirements fail despite a useful workbook."
+                    ),
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/deliverables/review.xlsx.",
+                        "Inspected trajectory file: workbook creation command was present.",
+                        (
+                            "Score calibration/cap audit: the wrong revenue basis and missing buy-plan "
+                            "comparisons make the maximum score allowed 0.65."
+                        ),
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p))
+
+        lowered = result.reasoning.lower()
+        assert result.score is None
+        assert "foundational" in lowered
+        assert "above-midpoint" in lowered
+
+    @pytest.mark.parametrize(
+        ("payload", "expected_reason"),
+        [
+            ({"score": 1, "reasoning": "complete"}, "evidence"),
+            ({"score": 1, "reasoning": "complete", "evidence": []}, "evidence"),
+            ({"score": 1, "reasoning": "complete", "evidence": "Checked report.md"}, "evidence"),
+            ({"score": 1, "reasoning": "", "evidence": ["Checked report.md"]}, "reasoning"),
+            ({"score": 1, "evidence": ["Checked report.md"]}, "reasoning"),
+        ],
+    )
+    def test_missing_audit_fields_are_invalid(
+        self, payload: dict[str, Any], expected_reason: str, tmp_path: pathlib.Path
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(json.dumps(payload))
+        result = read_guidance_score(str(p))
+        assert result.score is None
+        assert expected_reason in result.reasoning.lower()
+
+    @pytest.mark.parametrize(
+        ("payload", "expected_reason"),
+        [
+            ({"reasoning": "missing"}, "missing"),
+            ({"score": "high", "reasoning": "bad"}, "numeric"),
+            ({"score": True, "reasoning": "bad"}, "numeric"),
+            ({"score": -0.01, "reasoning": "bad"}, "range"),
+            ({"score": 1.01, "reasoning": "bad"}, "range"),
+        ],
+    )
+    def test_invalid_score_shapes(self, payload: dict[str, Any], expected_reason: str, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(json.dumps(payload))
+        result = read_guidance_score(str(p))
+        assert result.score is None
+        assert expected_reason in result.reasoning.lower()
+
+    def test_invalid_json(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text("not json")
+        result = read_guidance_score(str(p))
+        assert result.score is None
+        assert "invalid JSON" in result.reasoning
+
+    def test_missing_required_action_audit_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Inspected trajectory file for command failures",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_action_side_effect_audit=True)
+
+        assert result.score is None
+        assert "action/side-effect audit" in result.reasoning.lower()
+
+    def test_weak_required_action_audit_label_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Action/side-effect audit: checked expected external actions before grading.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_action_side_effect_audit=True)
+
+        assert result.score is None
+        assert "action/side-effect audit" in result.reasoning.lower()
+
+    def test_required_action_audit_accepts_named_evidence_item(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Action/side-effect audit: inspected trajectory; no send-email or calendar-event calls occurred.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_action_side_effect_audit=True)
+
+        assert result.score == 0.8
+
+    def test_required_action_audit_accepts_trajectory_forbidden_action_evidence(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Trajectory check: inspected gandalf_trajectory.json; no Shopify/QuickBooks updates, emails, calendar events, or other forbidden side effects were observed.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_action_side_effect_audit=True)
+
+        assert result.score == 0.8
+
+    def test_missing_required_output_location_conflict_audit_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_output_location_conflict_audit=True)
+
+        assert result.score is None
+        assert "output-location conflict audit" in result.reasoning.lower()
+
+    def test_required_output_location_conflict_audit_accepts_named_evidence_item(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Output-location conflict audit: task requested /home/agent/workspace/deliverables; guidance named /tmp/output; actual artifact was task-instructed and accessible.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_output_location_conflict_audit=True)
+
+        assert result.score == 0.8
+
+    def test_weak_required_output_location_conflict_audit_label_is_invalid(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Output-location conflict audit: checked the output path before grading.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_output_location_conflict_audit=True)
+
+        assert result.score is None
+        assert "output-location conflict audit" in result.reasoning.lower()
+
+    def test_missing_required_source_availability_audit_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        evidence = [
+            "Workspace/artifact check: read /workspace/report.md.",
+            "Inspected trajectory file: final command succeeded.",
+            "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+        ]
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": evidence,
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_source_availability_audit=True)
+
+        assert result.score is None
+        assert "source availability audit" in result.reasoning.lower()
+        assert result.evidence == evidence
+
+    def test_weak_required_source_availability_audit_label_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Source availability audit: checked expected sources before grading.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_source_availability_audit=True)
+
+        assert result.score is None
+        assert "source availability audit" in result.reasoning.lower()
+
+    def test_required_source_availability_audit_accepts_named_evidence_item(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Source availability audit: Shopify exports were not accessible; /workspace/plan.csv was accessible.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_source_availability_audit=True)
+
+        assert result.score == 0.8
+
+    def test_required_source_availability_audit_accepts_accessibility_evidence(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Source availability audit: confirmed expected source workbooks exist under Operations; Shopify exports were missing.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_source_availability_audit=True)
+
+        assert result.score == 0.8
+
+    def test_required_source_availability_audit_accepts_trajectory_source_directory_evidence(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Source availability audit: trajectory step 7 listed /home/agent/workspace/tool-outputs/shopify and quickbooks_sql source directories as empty.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_source_availability_audit=True)
+
+        assert result.score == 0.8
+
+    def test_missing_required_source_verification_audit_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_source_verification_audit=True)
+
+        assert result.score is None
+        assert "source verification audit" in result.reasoning.lower()
+
+    def test_weak_required_source_verification_audit_label_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Source verification audit: checked the source data and compared it to the artifact.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_source_verification_audit=True)
+
+        assert result.score is None
+        assert "source verification audit" in result.reasoning.lower()
+
+    def test_required_source_verification_audit_accepts_named_evidence_item(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Source verification audit: recomputed source totals from /workspace/orders.csv and compared them to the workbook.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_source_verification_audit=True)
+
+        assert result.score == 0.8
+
+    def test_required_source_verification_audit_accepts_independent_verification_evidence(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Independent source verification with Python on /workspace/orders.csv recalculated revenue and compared it to the workbook.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_source_verification_audit=True)
+
+        assert result.score == 0.8
+
+    def test_required_source_verification_audit_accepts_script_output_evidence(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.8,
+                    "reasoning": "Solid result.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/report.md.",
+                        "Source verification script output from orders.csv: 20 Q1 rows, gross $5,782.75, and net payout $5,141.46.",
+                        "Inspected trajectory file: final command succeeded.",
+                        "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(str(p), require_source_verification_audit=True)
+
+        assert result.score == 0.8
+
+    def test_unlabeled_source_guidance_conflict_is_invalid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.5,
+                    "reasoning": "Mixed result with source and guidance conflicts.",
+                    "evidence": [
+                        "Workspace/artifact check: read /workspace/deliverables/report.xlsx.",
+                        "Trajectory check: gandalf_trajectory.json shows the agent created the workbook.",
+                        (
+                            "Source availability audit: the source file 2026_COGS_and_Margin.xlsx and "
+                            "Financial/Budget_FY2026.xlsx were accessible and inspected."
+                        ),
+                        (
+                            "Source verification audit: independently recomputed category totals from "
+                            "/workspace/2026_COGS_and_Margin.xlsx."
+                        ),
+                        (
+                            "Category source check: the captured COGS tracker values match the workbook but do not "
+                            "meet the guidance's expected category figures."
+                        ),
+                        "Score calibration/cap audit: mixed source-grounding defects cap the score at 0.65.",
+                    ],
+                }
+            )
+        )
+
+        result = read_guidance_score(
+            str(p),
+            require_source_availability_audit=True,
+            require_source_verification_audit=True,
+        )
+
+        assert result.score is None
+        assert "source/guidance conflict audit" in result.reasoning.lower()
+
+    def test_named_source_guidance_conflict_audit_is_valid(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "score.json"
+        evidence = [
+            "Workspace/artifact check: read /workspace/deliverables/report.xlsx.",
+            "Trajectory check: gandalf_trajectory.json shows the agent created the workbook.",
+            (
+                "Source availability audit: the source file 2026_COGS_and_Margin.xlsx and "
+                "Financial/Budget_FY2026.xlsx were accessible and inspected."
+            ),
+            (
+                "Source verification audit: independently recomputed category totals from "
+                "/workspace/2026_COGS_and_Margin.xlsx."
+            ),
+            (
+                "Source/guidance conflict audit: the captured tracker source values match the workbook "
+                "but do not meet the guidance's expected category figures; I treated the guidance's "
+                "golden checkpoints as authoritative for scoring because it names them as expected values."
+            ),
+            "Score calibration/cap audit: mixed source-grounding defects cap the score at 0.65.",
+        ]
+        p.write_text(
+            json.dumps(
+                {
+                    "score": 0.5,
+                    "reasoning": "Mixed result with a reconciled source/guidance conflict.",
+                    "evidence": evidence,
+                }
+            )
+        )
+
+        result = read_guidance_score(
+            str(p),
+            require_source_availability_audit=True,
+            require_source_verification_audit=True,
+        )
+
+        assert result.score == 0.5
+        assert result.evidence == evidence
+
+
+class TestRequiresSourceAvailabilityAudit:
+    def test_requires_audit_when_guidance_names_expected_source_files(self) -> None:
+        assert requires_source_availability_audit(
+            "Use Shopify and QuickBooks only where the files clearly support the interpretation.",
+            "Expected sources include Shopify/orders.xlsx, QuickBooks/bills.csv, and Files/Home/plan.csv.",
+        )
+
+    def test_requires_audit_when_task_uses_connector_data_as_source(self) -> None:
+        assert requires_source_availability_audit(
+            "Use Shopify, Faire, and QuickBooks as supporting context where files clearly support it.",
+            "Grade whether the analysis is source-grounded.",
+        )
+
+    def test_requires_audit_when_guidance_names_source_colon_files(self) -> None:
+        assert requires_source_availability_audit(
+            "Prepare the inventory plan.",
+            "Trend factors must be checked. Source: inventory_ledger.csv aggregated for both years.",
+        )
+
+    def test_does_not_require_audit_for_output_file_paths_only(self) -> None:
+        assert not requires_source_availability_audit(
+            "Save the finished workbook to /home/agent/workspace/deliverables/report.xlsx.",
+            "Grade the final artifact.",
+        )
+
+    def test_does_not_require_audit_for_external_action_only(self) -> None:
+        assert not requires_source_availability_audit(
+            "Create a report. Do not send email or create calendar events.",
+            "Verify no live action happened.",
+        )
+
+    def test_foundational_failure_language_ignores_missing_source_data_caveat(self) -> None:
+        assert not has_foundational_failure_language(
+            "The workbook correctly flags missing recipe COGS rather than treating it as true healthy margin."
+        )
+
+    def test_foundational_failure_language_detects_missing_required_outputs(self) -> None:
+        assert has_foundational_failure_language(
+            "The response did not produce the required Excel workbook or separate written-summary artifact."
+        )
+
+    def test_has_above_midpoint_justification_accepts_midpoint_because_evidence(self) -> None:
+        assert has_above_midpoint_justification(
+            [
+                (
+                    "Score calibration/cap audit: I score 0.58, above the midpoint of the 0.41-0.60 band "
+                    "only because the artifact is complete, source-grounded in many areas, and includes "
+                    "budget, QuickBooks, HR, concentration, limitations, and recommendations."
+                ),
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_named_evidence(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: Shopify was unavailable, while /workspace/source.csv was accessible.",
+            ]
+        )
+
+    def test_has_source_availability_audit_does_not_accept_weak_named_evidence(self) -> None:
+        assert not has_source_availability_audit(
+            [
+                "Source availability audit: checked expected sources before grading.",
+            ]
+        )
+
+    def test_has_source_availability_audit_requires_named_audit_item(self) -> None:
+        assert not has_source_availability_audit(
+            [
+                "Raw finance-source XML check: Copy of Jade Leaf LLC. Finances.xlsx August cells I3 and I6 "
+                "contain formulas but no cached values.",
+                "CSV verification: Labor_Sales/2025 labor v sales.csv has August Labor Cost $8,227.13.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_concrete_accessibility_evidence(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: confirmed expected source workbooks exist under Operations; the Shopify export was missing.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_workspace_containing_source_workbooks(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: /tmp/judge_workspace contains accessible source workbooks Operations/Delivery_Log_DAL_2024-2026.xlsx and Operations/Supplier_Log_DAL_2024-2026.xlsx.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_empty_tool_output_directories(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: trajectory step 7 listed /home/agent/workspace/tool-outputs/shopify and quickbooks_sql source directories as empty.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_no_named_source_export_found(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: initial rg --files listed annual plan files but no Shopify order-line export was found.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_no_expected_source_path_found(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: initial rg --files in /home/agent/workspace listed annual plan, fixed_asset_register.csv, and Faire files but no Shopify/orders.xlsx or orders.csv source export.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_not_present_expected_sources(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: expected CSVs such as shopify_products.csv, square_items.csv, qb_bills_all_20260429.csv, and qb_accounts_20260429.csv were not present as local files. Accessible sources included deliverables/data/shopify_orders.json and COGS_Recipe_Sheet.xlsx.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_sources_are_accessible(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: the plan CSV, Faire orders and payouts CSVs, captured Shopify export, generated workbook/email, and full trajectory are accessible in the cloned workspace.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_inverted_accessible_source_list(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: accessible in the cloned workspace were "
+                "Financial/Astor_Budget_FY2025.xlsx, Merchandising/Buy_Plan_SS25.xlsx, "
+                "Shopify orders/customers/products JSON exports, and TimeStation CSV files. "
+                "QuickBooks bill data was not a standalone local file but was visible in the "
+                "trajectory through quickbooks_sql search calls."
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_source_files_were_present(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: inventory_ledger.csv, inventory_master.csv, cycle_counts.csv, Water_Test_Appointments.csv, SKU_Cost_Master.csv, Campaigns.csv, Demand_Forecast_2026.xlsx, Budgets.xlsx, and related source files were present under the cloned workspace; source absence did not limit grading.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_independent_source_recomputation(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: retail_cafe_invoices_2025.csv was accessible and opened with Python; retail cafe invoices by Invoice Date were Jan $3,889.45, Feb $5,432.25, and Mar $7,448.47.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_connector_named_independent_verification(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: accessible Shopify source export tool-outputs/shopify/workspace/data/shopify_orders_2025.json was opened; using paid/partially_refunded, non-test, non-cancelled orders gave 2,961 orders and $462,401.04 subtotal revenue.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_retrieved_connector_source_outputs(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: trajectory/source check found accessible QuickBooks account, invoice, bill, and payment tool outputs in steps 13-16 and 20-25; step 28 exported Shopify orders; steps 10-11 viewed Faire orders and payouts exports.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_trajectory_check_with_source_exports(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: trajectory check confirmed QuickBooks account, invoice, bill, and payment source searches in steps 14-17 were accessible, step 29 exported Shopify February orders, and steps 11-12 viewed Faire orders and payouts files.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_trajectory_inspected_source_files(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: trajectory steps 4-38 show the agent inspected accessible source files, PDFs, finance/budget/goal workbooks, labor/sales reports, item sales, discounts, pricing, and inventory files.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_trajectory_explored_source_files(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: gandalf_trajectory.json has 56 steps; the agent inspected accessible source files and generated deliverables.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_trajectory_analytical_command_with_named_source(
+        self,
+    ) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: trajectory analytical command step 25 opened accessible Supplier_Pricing_History source category costs such as $12.70/$26.33 and claimed high margins.",
+            ]
+        )
+
+    def test_has_source_availability_audit_detects_extracted_source_workbook(self) -> None:
+        assert has_source_availability_audit(
+            [
+                "Source availability audit: trajectory step 17 opened accessible source workbook Copy of Jade Leaf LLC. Finances.xlsx with openpyxl data_only=True and showed August values blank for In-Store Cafe Sales.",
+            ]
+        )
+
+    def test_has_source_availability_audit_does_not_accept_generic_source_reads(self) -> None:
+        assert not has_source_availability_audit(
+            [
+                "Read source data at /workspace/data/orders.csv.",
+            ]
+        )
+
+    def test_has_source_availability_audit_does_not_accept_vague_used_source_claim(self) -> None:
+        assert not has_source_availability_audit(
+            [
+                "The response used source data for the analysis.",
+            ]
+        )
+
+    def test_has_source_availability_audit_does_not_accept_no_source_requirement(self) -> None:
+        assert not has_source_availability_audit(
+            [
+                "No source files should be required for this task.",
+            ]
+        )
+
+    def test_has_source_availability_audit_does_not_accept_external_action_absence(self) -> None:
+        assert not has_source_availability_audit(
+            [
+                "Action/side-effect audit: inspected trajectory and found no Shopify updates.",
+            ]
+        )
+
+    def test_has_source_availability_audit_does_not_accept_source_connector_action_absence(self) -> None:
+        assert not has_source_availability_audit(
+            [
+                "Trajectory check: tool calls were Shopify export_orders/customers/products; no Shopify updates were observed.",
+            ]
+        )
+
+    def test_has_source_availability_audit_does_not_accept_missing_artifact_references(self) -> None:
+        assert not has_source_availability_audit(
+            [
+                "Negative supporting-source check: grepping the workbook found no references to Shopify/orders.xlsx or QuickBooks/bills.csv.",
+            ]
+        )
+
+    def test_has_source_availability_audit_does_not_accept_score_calibration_source_mentions(self) -> None:
+        assert not has_source_availability_audit(
+            [
+                "Score calibration/cap audit: no hard caps for wrong revenue source, missing ranking, or missing plan comparison apply because the workbook includes directional context.",
+            ]
+        )
+
+    def test_has_source_availability_audit_does_not_accept_connector_tool_call_list_without_status(self) -> None:
+        assert not has_source_availability_audit(
+            [
+                "Trajectory check: gandalf_trajectory.json shows Shopify/Square export/list calls and QuickBooks search calls; no evidence of send/post/publish actions was found.",
+            ]
+        )
+
+    def test_has_source_availability_audit_does_not_accept_unchecked_expectations(self) -> None:
+        assert not has_source_availability_audit(
+            [
+                "Expected source files should be available for grading.",
+            ]
+        )
+
+
+class TestRequiresSourceVerificationAudit:
+    def test_requires_audit_when_guidance_requires_independent_verification(self) -> None:
+        assert requires_source_verification_audit(
+            "Build a workbook with exact revenue calculations.",
+            "Verification requirement: independently verify numerical claims against source files.",
+        )
+
+    def test_requires_audit_when_guidance_says_recompute_from_source_of_truth(self) -> None:
+        assert requires_source_verification_audit(
+            "Prepare a management summary.",
+            "Use source files as the source of truth for all exact figures and recompute key totals.",
+        )
+
+    def test_requires_audit_when_guidance_says_artifacts_checked_against_source_records(self) -> None:
+        assert requires_source_verification_audit(
+            "Create a pricing review workbook.",
+            (
+                "Use the source records as the source of truth. The model's workbook, final response, "
+                "or any other artifact should be checked against the source records, not treated as "
+                "the source of truth."
+            ),
+        )
+
+    def test_requires_audit_when_guidance_uses_golden_deliverable_as_source_of_truth(self) -> None:
+        assert requires_source_verification_audit(
+            "Prepare a planning diagnostic workbook.",
+            (
+                "Use the accompanying golden deliverable file as the source of truth for all exact figures, "
+                "detailed tables, and workbook structure. The golden deliverable tells you what the correct "
+                "answers are."
+            ),
+        )
+
+    def test_requires_audit_when_guidance_uses_deliverable_as_source_of_truth_for_exact_figures(self) -> None:
+        assert requires_source_verification_audit(
+            "Prepare a monthly variance review workbook.",
+            "Use the accompanying bronze deliverable as the source of truth for exact figures.",
+        )
+
+    def test_requires_audit_when_guidance_requires_tie_out_or_tolerance_checks(self) -> None:
+        assert requires_source_verification_audit(
+            "Prepare a Q1 performance review.",
+            "Dollar amounts accept within +/-2%; Q1 gross sales must tie out across Square and the COGS file.",
+        )
+
+    def test_does_not_require_audit_for_generic_source_availability(self) -> None:
+        assert not requires_source_verification_audit(
+            "Use Shopify and QuickBooks only where files clearly support the interpretation.",
+            "Expected sources include Shopify/orders.xlsx and QuickBooks/bills.csv.",
+        )
+
+    def test_does_not_require_audit_for_generic_source_grounding_language(self) -> None:
+        assert not requires_source_verification_audit(
+            "Prepare a management summary.",
+            "Grade whether the response is source-grounded and avoids unsupported claims.",
+        )
+
+    def test_has_source_verification_audit_detects_named_evidence(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Source verification audit: independently recomputed totals from /workspace/orders.csv and matched workbook revenue $1,234.56.",
+            ]
+        )
+
+    def test_source_guidance_conflict_language_detects_guidance_mismatch(self) -> None:
+        assert has_source_guidance_conflict_language(
+            "The captured COGS tracker values match the workbook but do not meet the guidance's expected category figures."
+        )
+
+    def test_source_guidance_conflict_audit_requires_named_authority_decision(self) -> None:
+        assert has_source_guidance_conflict_audit(
+            [
+                (
+                    "Source/guidance conflict audit: the captured tracker source values match the workbook "
+                    "but do not meet the guidance's expected category figures; I treated the guidance's golden "
+                    "checkpoints as authoritative for scoring."
+                ),
+            ]
+        )
+        assert not has_source_guidance_conflict_audit(
+            [
+                "Source/guidance conflict audit: the captured tracker source values do not meet the guidance figures.",
+            ]
+        )
+
+    def test_source_guidance_conflict_audit_accepts_no_conflict_found(self) -> None:
+        assert has_source_guidance_conflict_audit(
+            [
+                (
+                    "Source/guidance conflict audit: no substantive conflict was found between the accessible "
+                    "CSV-converted source workbooks and the guidance golden values for the scored checkpoints; "
+                    "the raw Prairie Gas Co count appears as 47 in the CSV, within the guidance's stated tolerance "
+                    "for 46 vs 47."
+                ),
+            ]
+        )
+
+    def test_source_guidance_conflict_audit_accepts_guidance_acceptance_decision(self) -> None:
+        assert has_source_guidance_conflict_audit(
+            [
+                (
+                    "Source/guidance conflict audit: my numeric-prefix extraction produced Q1 2026 = "
+                    "15,516.35 rather than the golden exclusion anchor 15,459.95, but the guidance "
+                    "explicitly accepts Q1 2026 values in the 15,460-15,585 range depending on "
+                    "non-numeric handling. This does not excuse the agent's Q1 2025 and Q2 2025 "
+                    "errors, because those guidance figures are unaffected and matched direct source parsing."
+                ),
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_recomputed_results(self) -> None:
+        assert has_source_verification_audit(
+            [
+                (
+                    "Source verification audit: independently recomputed Shopify FY2025 included orders from "
+                    "source JSON using financial_status paid or partially_refunded and not cancelled. "
+                    "Results: 2,961 orders, subtotal_price net merchandise revenue $462,401.04."
+                ),
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_independent_source_verification_evidence(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Independent source verification with Python on /workspace/orders.csv calculated 2,961 orders and compared them to the workbook.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_connector_named_independent_verification(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Independent Shopify verification from tool-outputs/shopify/workspace/data/shopify_orders_2025.json using paid/partially_refunded, non-test, non-cancelled orders gave 2,961 orders and $462,401.04 subtotal revenue.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_independent_source_calculation(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Independent source calculation from 2025_year_end_summary.csv: TOTAL REVENUE row is Q1 22,648.48, Q2 36,661.08, Q3 23,036.36, Q4 67,422.88, annual 149,768.80.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_script_output_evidence(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Source verification script output from faire-payouts-summary.csv: 20 Q1 payout rows, gross $5,782.75, net payout $5,141.46.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_verifier_script_totals_without_source_filename(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Independent source verification with verify_sources.py: margin tracker Q1 totals are 315 rows, gross $193,175.25, cost $153,756.96, and budget source Total Revenue Q1 is $196,964.00.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_bronze_deliverable_source_truth(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Source verification audit: compared workbook values against the bronze deliverable source of truth and confirmed POS actual $343.00, Online actual $1,645.25, Faire net $222.98, and Total Revenue $6,888.38.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_source_truth_checkpoint_comparison(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Source verification audit: I compared the delivered calculations and shortlist against the grading source-of-truth checkpoints and inspected the agent's source choices in trajectory. The expected push-now shortlist is SPK-HUDS-PETN-2022, WOW-WEIN-GRNE-2019, WOW-PAGO-VERD-2021, ROS-MANO-TAVE-2020, RNW-TEMA-PINO-2023, and RNW-CATS-PINO-2020 with a 5-6% cap from Verdejo; the delivered shortlist/margin math uses supplier cost and a 15% tier, so the central source-backed margin and SKU findings are not verified or correct.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_cogs_tracker_and_budget_recomputation(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Source verification audit: my verify_metrics.py recomputation from the accessible COGS tracker returned Q1 315 rows, gross $193,175.25, bought price $153,756.96, commission $39,050.14; the FY2026 budget recomputation returned Q1 Total Revenue $196,964.00, Total COGS $156,920.00, Gross Profit $40,044.00, and April Total Revenue plan $69,177.60.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_independent_source_check(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Independent source check with Python on the invoice CSVs: retail cafe invoices by Invoice Date were Jan $3,889.45, Feb $5,432.25, and Mar $7,448.47.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_financial_source_check_with_file(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Financial source check: historical_pnl_2021_2025.csv contains FY 2025 discounts of -$13,641.35 and returns of $978.08.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_source_check_with_python(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Source check with Python: historical_pnl_2021_2025.csv contains FY 2025 Total discounts of -13641.35 and returns of 978.08.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_independently_checked_source_csvs(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Independently checked available source CSVs with Python: 2026_annual_plan.csv gives Q1 total target $34,555.00 and Faire target $5,335.00.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_raw_connector_json_description(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Source verification audit: from raw Shopify and Square JSON I recomputed latest paid non-cancelled Shopify order date as 2026-04-18 and latest completed Square sale date as 2026-04-19.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_raw_order_json_description(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Source verification audit: recomputing from raw order JSON gave almond-butter-lover 15 Shopify units, 0 Square units, 15 total.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_csv_verification_with_source_path(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "CSV verification: Labor_Sales/2025 labor v sales.csv has August Labor Cost $8,227.13, Net Sales $20,179.93, and Labor Percentage 40.77%.",
+            ]
+        )
+
+    def test_has_source_verification_audit_detects_raw_finance_source_xml_check(self) -> None:
+        assert has_source_verification_audit(
+            [
+                "Raw finance-source XML check: in Copy of Jade Leaf LLC. Finances.xlsx, August cells I3, I6, I7, I10, and I11 contain formulas but no cached values.",
+            ]
+        )
+
+    def test_has_source_verification_audit_does_not_accept_generic_source_grounding(self) -> None:
+        assert not has_source_verification_audit(
+            [
+                "The final workbook is source-grounded and cites Shopify data.",
+            ]
+        )
+
+    def test_has_source_verification_audit_does_not_accept_generic_source_check(self) -> None:
+        assert not has_source_verification_audit(
+            [
+                "Source check: reviewed the workbook and it seemed plausible.",
+            ]
+        )
+
+    def test_has_source_verification_audit_does_not_accept_source_choice_only(self) -> None:
+        assert not has_source_verification_audit(
+            [
+                "Trajectory/source check: steps 13-16 and 20-25 used QuickBooks account, invoice, bill, and payment tools; step 28 exported Shopify orders.",
+            ]
+        )
+
+    def test_has_source_verification_audit_does_not_accept_workspace_artifact_source_labels(self) -> None:
+        assert not has_source_verification_audit(
+            [
+                "Workspace/artifact check: found /workspace/deliverables/report.xlsx (50,327 bytes) and parsed sheets including Channel_Source and Data_Sources_Limits.",
+            ]
+        )
+
+    def test_has_source_verification_audit_does_not_accept_source_availability_searches(self) -> None:
+        assert not has_source_verification_audit(
+            [
+                "Trajectory check: step 12's find command returned no files under /home/agent/workspace/tool-outputs and found only empty Shopify source directories.",
+            ]
+        )
+
+    def test_has_source_verification_audit_does_not_accept_score_cap_source_mentions(self) -> None:
+        assert not has_source_verification_audit(
+            [
+                "Score calibration/cap audit: wrong revenue source caps the score at 0.65 because source-grounding was incomplete.",
+            ]
+        )
+
+    def test_has_source_verification_audit_does_not_accept_unchecked_expectations(self) -> None:
+        assert not has_source_verification_audit(
+            [
+                "The workbook should be compared against source files.",
+            ]
+        )
+
+
+class TestRequiresOutputLocationConflictAudit:
+    def test_requires_audit_when_instruction_and_guidance_paths_differ(self) -> None:
+        assert requires_output_location_conflict_audit(
+            "Save the workbook to /home/agent/workspace/deliverables.",
+            "Required artifact: workbook in /tmp/output.",
+        )
+
+    def test_does_not_require_audit_when_paths_match(self) -> None:
+        assert not requires_output_location_conflict_audit(
+            "Save the workbook to /tmp/output.",
+            "Required artifact: workbook in /tmp/output.",
+        )
+
+    def test_does_not_require_audit_for_specific_file_inside_requested_directory(self) -> None:
+        assert not requires_output_location_conflict_audit(
+            "Save the workbook to /home/agent/workspace/deliverables.",
+            "Required artifact: /home/agent/workspace/deliverables/report.xlsx.",
+        )
+
+    def test_ignores_schema_and_source_data_paths_for_output_conflicts(self) -> None:
+        assert not requires_output_location_conflict_audit(
+            "Save final files to /home/agent/workspace/deliverables.",
+            (
+                "Inspect source data at /Home/2025_year_end_summary.csv and /Fair/products.xlsx. "
+                "Return JSON fields /score and /reasoning. "
+                "The artifact path is /home/agent/workspace/deliverables/report.xlsx."
+            ),
+        )
+
+    def test_does_not_require_audit_with_only_one_path_source(self) -> None:
+        assert not requires_output_location_conflict_audit(
+            "Save the workbook to /home/agent/workspace/deliverables.",
+            "Grade the workbook holistically.",
+        )
+
+    def test_has_output_location_conflict_audit_detects_concrete_path_comparison(self) -> None:
+        assert has_output_location_conflict_audit(
+            [
+                "Output-location conflict audit: task requested /home/agent/workspace/deliverables; guidance named /tmp/output; actual artifact was task-instructed and accessible.",
+            ]
+        )
+
+    def test_has_output_location_conflict_audit_detects_external_artifact_location(self) -> None:
+        assert has_output_location_conflict_audit(
+            [
+                "Output-location conflict audit: task and guidance required an Outlook Drafts email; trajectory verified the actual artifact location is Drafts and no workspace deliverable was required.",
+            ]
+        )
+
+    def test_has_output_location_conflict_audit_does_not_accept_weak_named_evidence(self) -> None:
+        assert not has_output_location_conflict_audit(
+            [
+                "Output-location conflict audit: checked the output path before grading.",
+            ]
+        )
+
+
+class TestRequiresActionSideEffectAudit:
+    def test_requires_audit_for_external_email_or_calendar_actions(self) -> None:
+        assert requires_action_side_effect_audit(
+            "Create a report. Do not send email or create calendar events.",
+            "Verify no live action happened.",
+        )
+
+    def test_requires_audit_for_external_system_updates(self) -> None:
+        assert requires_action_side_effect_audit(
+            "Prepare a workbook only.",
+            "Verify no Shopify update, Square update, or QuickBooks update occurred.",
+        )
+
+    def test_does_not_require_audit_for_supporting_schedules(self) -> None:
+        assert not requires_action_side_effect_audit(
+            "Create an Excel workbook with supporting schedules and charts.",
+            "The workbook should include a monthly demand schedule.",
+        )
+
+    def test_does_not_require_audit_for_submitted_as_quality_language(self) -> None:
+        assert not requires_action_side_effect_audit(
+            "Create a manager-ready memo.",
+            "Do not over-credit a model that submitted wrong figures or submits a technical summary.",
+        )
+
+    def test_does_not_require_audit_for_not_required_action_list(self) -> None:
+        assert not requires_action_side_effect_audit(
+            "Create a workbook and save it to deliverables.",
+            (
+                "Not required: word document, PDF, email draft or sent email, calendar event, "
+                "Shopify updates, QuickBooks updates, or budget edits."
+            ),
+        )
+
+    def test_does_not_require_audit_for_prompt_does_not_ask_for_external_actions(self) -> None:
+        assert not requires_action_side_effect_audit(
+            "Create an Excel workbook, Word summary, and management email draft in txt.",
+            (
+                "The prompt does not ask for an Outlook draft, sent email, PowerPoint deck, "
+                "calendar event, Instagram payload, local pickup campaign, or wholesale partner outreach action."
+            ),
+        )
+
+    def test_does_not_require_audit_for_no_external_artifact_required_sentence(self) -> None:
+        assert not requires_action_side_effect_audit(
+            "Create a workbook and save it to deliverables.",
+            "No word memo, email draft, sent email, PDF, calendar item, or system update is required.",
+        )
+
+    def test_does_not_require_audit_for_ground_truth_email_draft_reference(self) -> None:
+        assert not requires_action_side_effect_audit(
+            "Create an Excel workbook, Word summary, and management email draft in txt.",
+            "Do not use the submitted workbook, Word document, email draft, or any generated artifact as ground truth.",
+        )
+
+    def test_does_not_require_audit_for_text_draft_not_outlook_draft_disclaimer(self) -> None:
+        assert not requires_action_side_effect_audit(
+            "Create an Excel workbook, Word summary, and management email draft in txt.",
+            "It should not create or require an Outlook draft, because this prompt asks for a text email draft only.",
+        )
+
+    def test_does_not_require_audit_for_local_txt_email_draft_deliverable(self) -> None:
+        assert not requires_action_side_effect_audit(
+            "Create an Excel workbook, a Word summary, and a management email draft in txt.",
+            "A management email draft is created as a `.txt` file in `/home/agent/workspace/deliverables`.",
+        )
+
+    def test_does_not_require_audit_for_local_email_draft_rubric_section(self) -> None:
+        assert not requires_action_side_effect_audit(
+            "Create an Excel workbook, a Word summary, and a management email draft in txt.",
+            (
+                "The word summary and email draft are consistent with the workbook.\n\n"
+                "Section 11: Word Summary and Management Email Draft\n"
+                "Management email draft checks:\n"
+                "- A `.txt` email draft exists in `/home/agent/workspace/deliverables`.\n"
+                "- Creating an Outlook draft instead of the required `.txt` management email draft is wrong.\n"
+                "If no `.txt` management email draft is produced, cap the score at 0.75.\n"
+                "The word document and email draft should be consistent with the workbook.\n"
+                "Strong work includes a concise management word summary, and an email draft that accurately "
+                "summarizes the implications for management."
+            ),
+        )
+
+    def test_has_action_side_effect_audit_detects_named_evidence(self) -> None:
+        assert has_action_side_effect_audit(
+            [
+                "Action/side-effect audit: inspected trajectory; no send-email or calendar-event calls occurred.",
+            ]
+        )
+
+    def test_has_action_side_effect_audit_does_not_accept_weak_named_evidence(self) -> None:
+        assert not has_action_side_effect_audit(
+            [
+                "Action/side-effect audit: checked expected external actions before grading.",
+            ]
+        )
+
+    def test_has_action_side_effect_audit_detects_forbidden_action_absence(self) -> None:
+        assert has_action_side_effect_audit(
+            [
+                "Trajectory check: inspected gandalf_trajectory.json; no Shopify/QuickBooks updates, emails, calendar events, or other forbidden side effects were observed.",
+            ]
+        )
+
+    def test_has_action_side_effect_audit_detects_no_live_mutations(self) -> None:
+        assert has_action_side_effect_audit(
+            [
+                "Trajectory check: no evidence of send/post/publish/schedule or live Shopify/Square/QuickBooks mutations was found.",
+            ]
+        )
+
+    def test_has_action_side_effect_audit_detects_draft_state_evidence(self) -> None:
+        assert has_action_side_effect_audit(
+            [
+                "Action/side-effect audit: trajectory step 27 showed isDraft=true for the Outlook draft and no send-message call appeared.",
+            ]
+        )
+
+    def test_has_action_side_effect_audit_detects_unlabeled_draft_rather_than_send_evidence(self) -> None:
+        assert has_action_side_effect_audit(
+            [
+                "Trajectory check: steps 14-17 used QuickBooks account searches, step 29 exported Shopify February orders, and step 54 called outlook__create_draft_message rather than a send function.",
+            ]
+        )
+
+    def test_has_action_side_effect_audit_detects_unlabeled_no_email_send_evidence(self) -> None:
+        assert has_action_side_effect_audit(
+            [
+                "Trajectory check: no email send action or external email tooling was used; the agent created docx/txt draft files only, satisfying the draft-not-sent constraint.",
+            ]
+        )
+
+    def test_has_action_side_effect_audit_detects_no_send_action_appears(self) -> None:
+        assert has_action_side_effect_audit(
+            [
+                "Trajectory check: final creation step wrote /home/agent/workspace/deliverables/report.xlsx and draft files, then verified sheet names and email text; no Outlook send action appears.",
+            ]
+        )
+
+    def test_has_action_side_effect_audit_does_not_accept_plain_email_content(self) -> None:
+        assert not has_action_side_effect_audit(
+            [
+                "Email artifact check: parsed draft_email.txt and found a summary of Q1 actuals.",
+            ]
+        )
+
+    def test_has_action_side_effect_audit_does_not_accept_source_export_calls_only(self) -> None:
+        assert not has_action_side_effect_audit(
+            [
+                "Trajectory check: Shopify export_orders and QuickBooks search_bills calls were used as sources.",
+            ]
+        )
+
+    def test_has_action_side_effect_audit_does_not_accept_unchecked_expectations(self) -> None:
+        assert not has_action_side_effect_audit(
+            [
+                "The agent should not send email or update Shopify.",
+            ]
+        )
+
+
+class TestScoreCalibrationAudit:
+    def test_detects_no_cap_decision(self) -> None:
+        assert has_score_calibration_audit(
+            [
+                "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+            ]
+        )
+
+    def test_detects_band_and_ceiling_decision(self) -> None:
+        assert has_score_calibration_audit(
+            [
+                "Score calibration/cap audit: the verified gaps fit the 0.6-0.79 band; the strictest practical ceiling is about 0.65.",
+            ]
+        )
+
+    def test_detects_applied_known_failure_cap(self) -> None:
+        assert has_score_calibration_audit(
+            [
+                "Score calibration/cap audit: wrong-source known failure mode caps the result around 0.45-0.65 depending severity.",
+            ]
+        )
+
+    def test_does_not_accept_label_without_calibration_decision(self) -> None:
+        assert not has_score_calibration_audit(
+            [
+                "Score calibration/cap audit: reviewed the score.",
+            ]
+        )
+
+    def test_does_not_accept_bare_no_hard_cap_phrase(self) -> None:
+        assert not has_score_calibration_audit(
+            [
+                "Score calibration/cap audit: no hard cap applies.",
+            ]
+        )
+
+    def test_does_not_accept_vague_non_numeric_ceiling(self) -> None:
+        assert not has_score_calibration_audit(
+            [
+                "Score calibration/cap audit: the strictest practical ceiling is about the mid-0.6s due major source-grounding and numerical omissions.",
+            ]
+        )
+
+    def test_does_not_accept_vague_ceiling_with_only_selected_score_numeric(self) -> None:
+        assert not has_score_calibration_audit(
+            [
+                "Score calibration/cap audit: the strictest practical ceiling from the verified evidence is about the mid-0.6s due major source-grounding and numerical omissions, so 0.62 is appropriate.",
+            ]
+        )
+
+    def test_does_not_accept_plain_band_without_maximum(self) -> None:
+        assert not has_score_calibration_audit(
+            [
+                "Score calibration/cap audit: the verified gaps fit the 0.6-0.79 band, so 0.62 is appropriate.",
+            ]
+        )
+
+    def test_extracts_explicit_cap_ceiling(self) -> None:
+        assert extract_score_calibration_ceiling(
+            [
+                "Score calibration/cap audit: the strictest applicable cap is 0.60.",
+            ]
+        ) == pytest.approx(0.6)
+
+    def test_extracts_maximum_score_allowed(self) -> None:
+        assert extract_score_calibration_ceiling(
+            [
+                "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+            ]
+        ) == pytest.approx(1.0)
+
+    def test_extracts_range_cap_upper_bound(self) -> None:
+        assert extract_score_calibration_ceiling(
+            [
+                "Score calibration/cap audit: wrong-source known failure mode caps the result around 0.45-0.65 depending severity.",
+            ]
+        ) == pytest.approx(0.65)
+
+    def test_extracts_maximum_of_phrase(self) -> None:
+        assert extract_score_calibration_ceiling(
+            [
+                "Score calibration/cap audit: the hard cap applies, and the unsupported analysis supports a maximum of 0.5.",
+            ]
+        ) == pytest.approx(0.5)
+
+    def test_extracts_maximum_score_i_allow_phrase(self) -> None:
+        assert extract_score_calibration_ceiling(
+            [
+                "Score calibration/cap audit: because both required artifacts are absent, the maximum score I allow is 0.6.",
+            ]
+        ) == pytest.approx(0.6)
+
+    def test_extracts_score_as_maximum_phrase(self) -> None:
+        assert extract_score_calibration_ceiling(
+            [
+                "Score calibration/cap audit: central forecast numbers are outside tolerance, so I treated 0.59 as the maximum.",
+            ]
+        ) == pytest.approx(0.59)
+
+    def test_ignores_considered_but_not_applied_cap_when_extracting_ceiling(self) -> None:
+        assert extract_score_calibration_ceiling(
+            [
+                "Score calibration/cap audit: applicable caps are wrong revenue basis, strictest here about 0.60. I considered but did not apply the fabricated-data cap at 0.50 because most bad figures are source-derived; maximum supported score is about 0.60.",
+            ]
+        ) == pytest.approx(0.6)
+
+    def test_ignores_considered_cap_list_when_none_apply(self) -> None:
+        evidence = [
+            "Score calibration/cap audit: applicable score band is 0.61-0.80 because most required artifacts "
+            "and major sections exist but several key source reconciliation requirements are incomplete. "
+            "Considered caps for no spreadsheet (0.45), no txt drafts (0.70), today's-date anchors (0.65), "
+            "recipe COGS not used (0.60), and forbidden live actions (0.60); none directly apply. "
+            "Strictest applicable cap is therefore 1.00, and the chosen 0.72 reflects substantive omissions."
+        ]
+
+        assert has_score_calibration_audit(evidence)
+        assert extract_score_calibration_ceiling(evidence) == pytest.approx(1.0)
+
+    def test_extracts_maximum_justified_band_upper_bound(self) -> None:
+        assert extract_score_calibration_ceiling(
+            [
+                "Score calibration/cap audit: Maximum justified band is 0.4-0.6, and the severity of core-method failures supports 0.42.",
+            ]
+        ) == pytest.approx(0.6)
+
+    def test_extracts_cap_not_final_score_from_no_lower_cap_clause(self) -> None:
+        assert extract_score_calibration_ceiling(
+            [
+                "Score calibration/cap audit: the verified work falls in the 0.4-0.6 band. "
+                "I set the strictest applicable cap at 0.55; no lower hard cap was explicit, "
+                "and the final score of 0.45 reflects useful partial deliverables but major baseline misses.",
+            ]
+        ) == pytest.approx(0.55)
+
+    def test_extracts_cap_when_no_lower_cap_note_uses_commas(self) -> None:
+        evidence = [
+            "Score calibration/cap audit: I set the strictest applicable cap at 0.55, "
+            "no lower hard cap was explicit, and the final score of 0.45 reflects useful partial deliverables.",
+        ]
+
+        assert has_score_calibration_audit(evidence)
+        assert extract_score_calibration_ceiling(evidence) == pytest.approx(0.55)
+
+    def test_extracts_strictest_cap_not_selected_score_below_that_cap(self) -> None:
+        evidence = [
+            "Score calibration/cap audit: guidance says 0.4-0.6 is appropriate when core criteria are addressed "
+            "but notable shortcomings remain. The strictest applicable cap I applied is 0.60 for no Excel workbook "
+            "or separate summary artifacts; the unsupported merchant-fee adjustment justifies scoring below that "
+            "cap at 0.58.",
+        ]
+
+        assert has_score_calibration_audit(evidence)
+        assert extract_score_calibration_ceiling(evidence) == pytest.approx(0.60)
+
+    def test_does_not_extract_plain_score_band_as_ceiling(self) -> None:
+        assert (
+            extract_score_calibration_ceiling(
+                [
+                    "Score calibration/cap audit: the verified gaps fit the 0.6-0.79 band, so 0.62 is appropriate.",
+                ]
+            )
+            is None
+        )
+
+    def test_does_not_extract_mid_decimal_phrase_as_zero_ceiling(self) -> None:
+        assert (
+            extract_score_calibration_ceiling(
+                [
+                    "Score calibration/cap audit: the strictest practical ceiling is about the mid-0.6s, so 0.62 is appropriate.",
+                ]
+            )
+            is None
+        )
+
+
 class TestReadBatchVerdict:
     def test_valid_batch(self, tmp_path: pathlib.Path) -> None:
         p = tmp_path / "verdict.json"
@@ -384,6 +2774,28 @@ def make_batch_judge_input_json(tmp_path: pathlib.Path, n: int = 2) -> str:
         "workdir": str(tmp_path),
     }
     p = tmp_path / "batch_input.json"
+    p.write_text(json.dumps(data))
+    return str(p)
+
+
+def make_guidance_judge_input_json(
+    tmp_path: pathlib.Path,
+    *,
+    instructions: str = "do a thing",
+    judge_guidance: str = "Grade holistically.",
+) -> str:
+    """Write a minimal GuidanceJudgeInput JSON file and return its path."""
+    trajectory = tmp_path / "gandalf_trajectory.json"
+    trajectory.write_text(json.dumps({"steps": []}))
+    data = {
+        "model": "test-model",
+        "instructions": instructions,
+        "final_output": "done",
+        "workdir": str(tmp_path),
+        "trajectory_path": str(trajectory),
+        "judge_guidance": judge_guidance,
+    }
+    p = tmp_path / "guidance_input.json"
     p.write_text(json.dumps(data))
     return str(p)
 
@@ -580,6 +2992,219 @@ class TestRunJudgeBatch:
         assert data["llm_usage"]["prompt_tokens"] == 1000
         assert all(v["met"] is None for v in data["verdicts"])
         assert "Batch parsing blew up" in data["verdicts"][0]["reasoning"]
+
+
+class TestRunJudgeGuidance:
+    """Tests for run_judge_guidance — mocks run_agent_session to avoid OpenHands."""
+
+    @patch("gandalf.judge.run_agent_session", return_value=MOCK_USAGE)
+    def test_output_wraps_score_and_usage(self, mock_session: Any, tmp_path: pathlib.Path) -> None:  # noqa: ARG002
+        input_path = make_guidance_judge_input_json(tmp_path)
+        output_path = str(tmp_path / "output.json")
+
+        score_data = {
+            "score": 0.8,
+            "reasoning": "Solid result.",
+            "evidence": [
+                "Workspace/artifact check: read /workspace/output.txt.",
+                "Inspected trajectory file: final command succeeded.",
+                "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+            ],
+        }
+        with patch(
+            "gandalf.judge.make_verdict_path",
+            return_value=str(tmp_path / "guidance_score.json"),
+        ):
+            (tmp_path / "guidance_score.json").write_text(json.dumps(score_data))
+            run_judge_guidance(input_path, output_path)
+
+        data = json.loads((tmp_path / "output.json").read_text())
+        assert data["guidance_score"]["score"] == 0.8
+        assert data["guidance_score"]["reasoning"] == "Solid result."
+        assert data["llm_usage"]["cost_usd"] == 0.05
+
+    @patch("gandalf.judge.run_agent_session", return_value=MOCK_USAGE)
+    def test_prompt_names_judge_workspace_path(self, mock_session: Any, tmp_path: pathlib.Path) -> None:
+        input_path = make_guidance_judge_input_json(
+            tmp_path,
+            instructions="Save the workbook to /home/agent/workspace/deliverables/report.xlsx.",
+        )
+        output_path = str(tmp_path / "output.json")
+
+        score_data = {
+            "score": 0.8,
+            "reasoning": "Solid result.",
+            "evidence": [
+                "Workspace/artifact check: read /workspace/output.txt.",
+                "Inspected trajectory file: final command succeeded.",
+                "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+            ],
+        }
+        with patch(
+            "gandalf.judge.make_verdict_path",
+            return_value=str(tmp_path / "guidance_score.json"),
+        ):
+            (tmp_path / "guidance_score.json").write_text(json.dumps(score_data))
+            run_judge_guidance(input_path, output_path)
+
+        prompt = mock_session.call_args.args[3]
+        assert "<workspace_path>" in prompt
+        assert str(tmp_path) in prompt
+        assert "original container paths" in prompt.lower()
+
+    @patch("gandalf.judge.run_agent_session", return_value=MOCK_USAGE)
+    def test_preserves_usage_when_score_file_invalid(self, mock_session: Any, tmp_path: pathlib.Path) -> None:  # noqa: ARG002
+        input_path = make_guidance_judge_input_json(tmp_path)
+        output_path = str(tmp_path / "output.json")
+
+        with patch(
+            "gandalf.judge.make_verdict_path",
+            return_value=str(tmp_path / "guidance_score.json"),
+        ):
+            (tmp_path / "guidance_score.json").write_text(json.dumps({"score": 2, "reasoning": "bad"}))
+            run_judge_guidance(input_path, output_path)
+
+        data = json.loads((tmp_path / "output.json").read_text())
+        assert data["guidance_score"]["score"] is None
+        assert "range" in data["guidance_score"]["reasoning"].lower()
+        assert data["llm_usage"]["cost_usd"] == 0.05
+
+    @patch("gandalf.judge.run_agent_session", return_value=MOCK_USAGE)
+    def test_requires_action_audit_when_task_mentions_external_actions(
+        self,
+        mock_session: Any,  # noqa: ARG002
+        tmp_path: pathlib.Path,
+    ) -> None:
+        input_path = make_guidance_judge_input_json(
+            tmp_path,
+            instructions="Create the workbook, but do not send email or create calendar events.",
+            judge_guidance="Grade the final artifact and verify no live action happened.",
+        )
+        output_path = str(tmp_path / "output.json")
+
+        score_data = {
+            "score": 0.8,
+            "reasoning": "Solid result.",
+            "evidence": [
+                "Workspace/artifact check: read /workspace/report.md.",
+                "Inspected trajectory file for command failures",
+                "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+            ],
+        }
+        with patch(
+            "gandalf.judge.make_verdict_path",
+            return_value=str(tmp_path / "guidance_score.json"),
+        ):
+            (tmp_path / "guidance_score.json").write_text(json.dumps(score_data))
+            run_judge_guidance(input_path, output_path)
+
+        data = json.loads((tmp_path / "output.json").read_text())
+        assert data["guidance_score"]["score"] is None
+        assert "action/side-effect audit" in data["guidance_score"]["reasoning"].lower()
+        assert data["llm_usage"]["cost_usd"] == 0.05
+
+    @patch("gandalf.judge.run_agent_session", return_value=MOCK_USAGE)
+    def test_requires_output_location_conflict_audit_when_task_and_guidance_paths_differ(
+        self,
+        mock_session: Any,  # noqa: ARG002
+        tmp_path: pathlib.Path,
+    ) -> None:
+        input_path = make_guidance_judge_input_json(
+            tmp_path,
+            instructions="Save the workbook to /home/agent/workspace/deliverables.",
+            judge_guidance="Required artifact: workbook in /tmp/output.",
+        )
+        output_path = str(tmp_path / "output.json")
+
+        score_data = {
+            "score": 0.8,
+            "reasoning": "Solid result.",
+            "evidence": [
+                "Workspace/artifact check: read /workspace/report.md.",
+                "Inspected trajectory file: final command succeeded.",
+                "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+            ],
+        }
+        with patch(
+            "gandalf.judge.make_verdict_path",
+            return_value=str(tmp_path / "guidance_score.json"),
+        ):
+            (tmp_path / "guidance_score.json").write_text(json.dumps(score_data))
+            run_judge_guidance(input_path, output_path)
+
+        data = json.loads((tmp_path / "output.json").read_text())
+        assert data["guidance_score"]["score"] is None
+        assert "output-location conflict audit" in data["guidance_score"]["reasoning"].lower()
+        assert data["llm_usage"]["cost_usd"] == 0.05
+
+    @patch("gandalf.judge.run_agent_session", return_value=MOCK_USAGE)
+    def test_requires_source_availability_audit_when_guidance_names_expected_sources(
+        self,
+        mock_session: Any,  # noqa: ARG002
+        tmp_path: pathlib.Path,
+    ) -> None:
+        input_path = make_guidance_judge_input_json(
+            tmp_path,
+            instructions="Use Shopify and QuickBooks only where files clearly support the interpretation.",
+            judge_guidance="Expected sources include Shopify/orders.xlsx and QuickBooks/bills.csv.",
+        )
+        output_path = str(tmp_path / "output.json")
+
+        score_data = {
+            "score": 0.8,
+            "reasoning": "Solid result.",
+            "evidence": [
+                "Workspace/artifact check: read /workspace/report.md.",
+                "Inspected trajectory file: final command succeeded.",
+                "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+            ],
+        }
+        with patch(
+            "gandalf.judge.make_verdict_path",
+            return_value=str(tmp_path / "guidance_score.json"),
+        ):
+            (tmp_path / "guidance_score.json").write_text(json.dumps(score_data))
+            run_judge_guidance(input_path, output_path)
+
+        data = json.loads((tmp_path / "output.json").read_text())
+        assert data["guidance_score"]["score"] is None
+        assert "source availability audit" in data["guidance_score"]["reasoning"].lower()
+        assert data["llm_usage"]["cost_usd"] == 0.05
+
+    @patch("gandalf.judge.run_agent_session", return_value=MOCK_USAGE)
+    def test_requires_source_verification_audit_when_guidance_requires_independent_verification(
+        self,
+        mock_session: Any,  # noqa: ARG002
+        tmp_path: pathlib.Path,
+    ) -> None:
+        input_path = make_guidance_judge_input_json(
+            tmp_path,
+            instructions="Build a workbook with exact revenue calculations.",
+            judge_guidance="Verification requirement: independently verify numerical claims against source files.",
+        )
+        output_path = str(tmp_path / "output.json")
+
+        score_data = {
+            "score": 0.8,
+            "reasoning": "Solid result.",
+            "evidence": [
+                "Workspace/artifact check: read /workspace/report.md.",
+                "Source availability audit: source files were accessible in /workspace/data.",
+                "Inspected trajectory file: final command succeeded.",
+                "Score calibration/cap audit: no hard cap applies; maximum score allowed is 1.0.",
+            ],
+        }
+        with patch(
+            "gandalf.judge.make_verdict_path",
+            return_value=str(tmp_path / "guidance_score.json"),
+        ):
+            (tmp_path / "guidance_score.json").write_text(json.dumps(score_data))
+            run_judge_guidance(input_path, output_path)
+
+        data = json.loads((tmp_path / "output.json").read_text())
+        assert data["guidance_score"]["score"] is None
+        assert "source verification audit" in data["guidance_score"]["reasoning"].lower()
+        assert data["llm_usage"]["cost_usd"] == 0.05
 
 
 class TestBuildJudgePromptXMLTags:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,7 +12,11 @@ from gandalf.models import (
     CriterionResult,
     EvaluationInfo,
     GraderConfig,
+    GuidanceEvaluationInfo,
+    GuidanceJudgeInput,
+    GuidanceScore,
     JudgeInput,
+    LLMUsage,
     MCPServer,
     RubricItem,
     Verdict,
@@ -396,6 +400,128 @@ output_dir = "/logs/grader"
         assert restored.model == ji.model
         assert restored.final_output == ji.final_output
         assert len(restored.mcp_servers) == 1
+
+    def test_grading_mode_defaults_to_rubric(self) -> None:
+        cfg = GraderConfig(
+            instructions="test",
+            rubric_path="/rubric.json",
+            workdir="/workspace",
+            trajectory_path="/logs/trajectory.json",
+            output_dir="/logs/grader",
+        )
+        assert cfg.grading_mode == "rubric"
+
+    def test_guidance_config_accepts_inline_guidance_without_rubric(self) -> None:
+        cfg = GraderConfig(
+            grading_mode="guidance",
+            instructions="test",
+            judge_guidance="Grade holistically.",
+            workdir="/workspace",
+            trajectory_path="/logs/trajectory.json",
+            output_dir="/logs/grader",
+        )
+        assert cfg.grading_mode == "guidance"
+        assert cfg.rubric is None
+        assert cfg.rubric_path is None
+        assert cfg.judge_guidance == "Grade holistically."
+
+    def test_guidance_config_accepts_guidance_path_without_rubric(self) -> None:
+        cfg = GraderConfig(
+            grading_mode="guidance",
+            instructions="test",
+            judge_guidance_path="/tests/judge_guidance.md",
+            workdir="/workspace",
+            trajectory_path="/logs/trajectory.json",
+            output_dir="/logs/grader",
+        )
+        assert cfg.judge_guidance_path == "/tests/judge_guidance.md"
+
+    def test_guidance_config_requires_guidance(self) -> None:
+        with pytest.raises(ValidationError, match="judge_guidance"):
+            GraderConfig(
+                grading_mode="guidance",
+                instructions="test",
+                workdir="/workspace",
+                trajectory_path="/logs/trajectory.json",
+                output_dir="/logs/grader",
+            )
+
+    @pytest.mark.parametrize(
+        "field_value",
+        [
+            {"rubric": [RubricItem(criterion="c", weight=1.0)]},
+            {"rubric_path": "/rubric.json"},
+        ],
+    )
+    def test_guidance_config_rejects_rubric_fields(self, field_value: dict[str, Any]) -> None:
+        with pytest.raises(ValidationError, match="rubric"):
+            GraderConfig(
+                grading_mode="guidance",
+                instructions="test",
+                judge_guidance="Grade holistically.",
+                workdir="/workspace",
+                trajectory_path="/logs/trajectory.json",
+                output_dir="/logs/grader",
+                **field_value,
+            )
+
+    @pytest.mark.parametrize(
+        "field_value",
+        [
+            {"batch_splits": 2},
+            {"batch_timeout": 120},
+            {"max_concurrency": 2},
+        ],
+    )
+    def test_guidance_config_rejects_batch_only_fields(self, field_value: dict[str, Any]) -> None:
+        with pytest.raises(ValidationError, match="guidance"):
+            GraderConfig(
+                grading_mode="guidance",
+                instructions="test",
+                judge_guidance="Grade holistically.",
+                workdir="/workspace",
+                trajectory_path="/logs/trajectory.json",
+                output_dir="/logs/grader",
+                **field_value,
+            )
+
+    def test_guidance_judge_input_roundtrip(self) -> None:
+        gi = GuidanceJudgeInput(
+            model="test-model",
+            instructions="test",
+            final_output="done",
+            workdir="/workspace",
+            trajectory_path="/workspace/gandalf_trajectory.json",
+            judge_guidance="Grade holistically.",
+            mcp_servers=[MCPServer(name="srv", command="/bin/srv")],
+        )
+        raw = gi.model_dump_json()
+        restored = GuidanceJudgeInput.model_validate_json(raw)
+        assert restored.trajectory_path == "/workspace/gandalf_trajectory.json"
+        assert restored.judge_guidance == "Grade holistically."
+        assert len(restored.mcp_servers) == 1
+
+    def test_guidance_score_roundtrip(self) -> None:
+        score = GuidanceScore(score=0.875, reasoning="Mostly complete.", evidence=["Checked output.txt"])
+        raw = score.model_dump_json()
+        restored = GuidanceScore.model_validate_json(raw)
+        assert restored.score == 0.875
+        assert restored.evidence == ["Checked output.txt"]
+
+    def test_guidance_evaluation_info_shape(self) -> None:
+        info = GuidanceEvaluationInfo(
+            reward=0.75,
+            score=0.75,
+            reasoning="Good work.",
+            evidence=["Read report.md"],
+            llm_usage=LLMUsage(cost_usd=0.1),
+        )
+        data = info.model_dump()
+        assert data["grading_mode"] == "guidance"
+        assert data["reward"] == 0.75
+        assert data["score"] == 0.75
+        assert data["llm_usage"]["cost_usd"] == 0.1
+        assert data["errored"] is False
 
 
 class TestMutualExclusivity:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -17,6 +17,8 @@ from gandalf.models import (
     BatchJudgeInput,
     CriterionResult,
     GraderConfig,
+    GuidanceJudgeInput,
+    GuidanceScore,
     JudgeInput,
     LLMUsage,
     RubricItem,
@@ -33,6 +35,9 @@ from gandalf.orchestrator import (
     resolve_judge_guidance,
     resolve_judge_prompt,
     run_batch_concurrent,
+    run_guidance,
+    run_guidance_judge,
+    run_guidance_retry_guidance,
     run_individual,
     run_judge,
     write_info,
@@ -570,6 +575,385 @@ class TestSandboxUserNone:
         assert len(verdicts) == 2
         assert all(v.met is True for v in verdicts)
         assert usage.cost_usd == 0.01
+
+
+class TestGuidanceModeOrchestration:
+    """Tests for the guidance-mode outer orchestration path."""
+
+    @patch("gandalf.orchestrator.clone_workspace")
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_run_guidance_judge_copies_trajectory_and_uses_guidance_flag(
+        self,
+        mock_run: Any,
+        mock_clone: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        workdir = tmp_path / "workspace"
+        workdir.mkdir()
+        (workdir / "artifact.txt").write_text("result")
+        trajectory = tmp_path / "trajectory.json"
+        trajectory.write_text(json.dumps({"steps": [{"source": "agent", "message": "done"}]}))
+
+        clone_dir = tmp_path / "clone"
+        clone_dir.mkdir()
+        mock_clone.return_value = str(clone_dir)
+        captured: dict[str, Any] = {}
+
+        def capture(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            input_path = pathlib.Path(cmd[cmd.index("--input") + 1])
+            output_path = pathlib.Path(cmd[cmd.index("--output") + 1])
+            payload = json.loads(input_path.read_text())
+            copied_trajectory = pathlib.Path(payload["trajectory_path"])
+            captured["cmd"] = cmd
+            captured["payload"] = payload
+            captured["trajectory_exists"] = copied_trajectory.exists()
+            captured["trajectory_content"] = json.loads(copied_trajectory.read_text())
+            output_path.write_text(
+                json.dumps(
+                    {
+                        "guidance_score": {
+                            "score": 0.9,
+                            "reasoning": "Strong result.",
+                            "evidence": ["Inspected artifact.txt"],
+                        },
+                        "llm_usage": {"cost_usd": 0.2, "prompt_tokens": 10},
+                    }
+                )
+            )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = capture
+        judge_input = GuidanceJudgeInput(
+            model="test-model",
+            instructions="test",
+            final_output="done",
+            workdir=str(workdir),
+            trajectory_path=str(trajectory),
+            judge_guidance="Grade holistically.",
+        )
+
+        score, usage = run_guidance_judge(
+            judge_input,
+            sandbox_user=None,
+            trace_path=str(tmp_path / "trace.txt"),
+            timeout=123,
+        )
+
+        assert score.score == 0.9
+        assert usage.cost_usd == 0.2
+        assert "--guidance" in captured["cmd"]
+        assert captured["payload"]["workdir"] == str(clone_dir)
+        assert captured["payload"]["trajectory_path"] == str(clone_dir / "gandalf_trajectory.json")
+        assert captured["trajectory_exists"] is True
+        assert captured["trajectory_content"]["steps"][0]["message"] == "done"
+
+    @patch("gandalf.orchestrator.clone_workspace")
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_run_guidance_judge_preserves_usage_on_invalid_score(
+        self,
+        mock_run: Any,
+        mock_clone: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        trajectory = tmp_path / "trajectory.json"
+        trajectory.write_text(json.dumps({"steps": []}))
+        clone_dir = tmp_path / "clone"
+        clone_dir.mkdir()
+        mock_clone.return_value = str(clone_dir)
+
+        def write_invalid_score(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            output_path = pathlib.Path(cmd[cmd.index("--output") + 1])
+            output_path.write_text(
+                json.dumps(
+                    {
+                        "guidance_score": {"score": 2, "reasoning": "too high"},
+                        "llm_usage": {"cost_usd": 0.3, "prompt_tokens": 11},
+                    }
+                )
+            )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = write_invalid_score
+        judge_input = GuidanceJudgeInput(
+            model="test-model",
+            instructions="test",
+            final_output="done",
+            workdir=str(tmp_path),
+            trajectory_path=str(trajectory),
+            judge_guidance="Grade holistically.",
+        )
+
+        score, usage = run_guidance_judge(
+            judge_input,
+            sandbox_user=None,
+            trace_path=str(tmp_path / "trace.txt"),
+        )
+
+        assert score.score is None
+        assert "range" in score.reasoning.lower()
+        assert usage.cost_usd == 0.3
+
+    @patch("gandalf.orchestrator.run_guidance_judge")
+    def test_run_guidance_retries_invalid_score_then_succeeds(
+        self,
+        mock_run_guidance_judge: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        trajectory = tmp_path / "trajectory.json"
+        trajectory.write_text(json.dumps({"steps": []}))
+        config = GraderConfig(
+            grading_mode="guidance",
+            instructions="test",
+            judge_guidance="Grade holistically.",
+            workdir=str(tmp_path),
+            trajectory_path=str(trajectory),
+            output_dir=str(output_dir),
+            judge_retries=1,
+        )
+        mock_run_guidance_judge.side_effect = [
+            (GuidanceScore(score=None, reasoning="Missing score.", evidence=[]), LLMUsage(cost_usd=0.1)),
+            (GuidanceScore(score=0.81234, reasoning="Recovered.", evidence=["Checked files"]), LLMUsage(cost_usd=0.2)),
+        ]
+
+        score, usage, initial_errored = run_guidance(
+            config,
+            final_output="done",
+            instructions="test",
+            judge_guidance="Grade holistically.",
+            judge_prompt=None,
+        )
+
+        assert score.score == 0.8123
+        assert usage.cost_usd == pytest.approx(0.3)
+        assert initial_errored is True
+        assert mock_run_guidance_judge.call_count == 2
+        first_input = mock_run_guidance_judge.call_args_list[0].args[0]
+        retry_input = mock_run_guidance_judge.call_args_list[1].args[0]
+        assert first_input.judge_guidance == "Grade holistically."
+        assert retry_input.judge_guidance != first_input.judge_guidance
+        assert "Grade holistically." in retry_input.judge_guidance
+        assert "previous guidance judge output was rejected" in retry_input.judge_guidance
+        assert "Missing score." in retry_input.judge_guidance
+
+    def test_run_guidance_retry_guidance_preserves_original_and_adds_failure_context(self) -> None:
+        guidance = run_guidance_retry_guidance(
+            "Grade with the customer-facing guidance.",
+            GuidanceScore(
+                score=None,
+                reasoning='Guidance score missing required "Source availability audit" evidence item.',
+                evidence=[
+                    "Workspace/artifact check: read /workspace/report.xlsx.",
+                    "Inspected trajectory file: final command succeeded.",
+                ],
+            ),
+        )
+
+        assert guidance.startswith("Grade with the customer-facing guidance.")
+        assert "previous guidance judge output was rejected" in guidance
+        assert "Source availability audit" in guidance
+        assert "perform a fresh holistic evaluation" in guidance
+        assert "do not change the score merely to satisfy validation" in guidance
+        assert "Workspace/artifact check: read /workspace/report.xlsx." in guidance
+
+    def test_run_guidance_retry_guidance_adds_above_midpoint_repair_example(self) -> None:
+        guidance = run_guidance_retry_guidance(
+            "Grade with the customer-facing guidance.",
+            GuidanceScore(
+                score=None,
+                reasoning=(
+                    "Guidance score validation failed: near declared ceiling with foundational failure language "
+                    "requires an explicit above-midpoint justification in the Score calibration/cap audit."
+                ),
+                evidence=[
+                    "Score calibration/cap audit: maximum score allowed is 0.60.",
+                ],
+            ),
+        )
+
+        assert "above-midpoint validation repair" in guidance.lower()
+        assert "score calibration/cap audit" in guidance.lower()
+        assert "above the midpoint because" in guidance.lower()
+        assert "name the central requirements" in guidance.lower()
+
+    def test_run_guidance_retry_guidance_adds_source_audit_repair_examples(self) -> None:
+        guidance = run_guidance_retry_guidance(
+            "Grade with the customer-facing guidance.",
+            GuidanceScore(
+                score=None,
+                reasoning=(
+                    'Guidance score validation failed: missing required "Source availability audit" '
+                    'evidence item; missing required "Source verification audit" evidence item.'
+                ),
+                evidence=[
+                    "Trajectory/source check: recomputed Shopify totals from orders.json.",
+                ],
+            ),
+        )
+        lowered = guidance.lower()
+
+        assert "source audit validation repair" in lowered
+        assert "source availability audit:" in lowered
+        assert "source verification audit:" in lowered
+        assert "use the exact audit labels" in lowered
+
+    @patch("gandalf.orchestrator.run_guidance_judge")
+    def test_run_guidance_retry_guidance_accumulates_validation_failures(
+        self,
+        mock_run_guidance_judge: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        trajectory = tmp_path / "trajectory.json"
+        trajectory.write_text(json.dumps({"steps": []}))
+        config = GraderConfig(
+            grading_mode="guidance",
+            instructions="test",
+            judge_guidance="Grade holistically.",
+            workdir=str(tmp_path),
+            trajectory_path=str(trajectory),
+            output_dir=str(output_dir),
+            judge_retries=2,
+        )
+        mock_run_guidance_judge.side_effect = [
+            (
+                GuidanceScore(
+                    score=None,
+                    reasoning='Guidance score missing required "Source availability audit" evidence item.',
+                    evidence=["Workspace/artifact check: read /workspace/report.xlsx."],
+                ),
+                LLMUsage(cost_usd=0.1),
+            ),
+            (
+                GuidanceScore(
+                    score=None,
+                    reasoning='Guidance score missing required "Source verification audit" evidence item.',
+                    evidence=["Source availability audit: /workspace/orders.csv was accessible."],
+                ),
+                LLMUsage(cost_usd=0.1),
+            ),
+            (GuidanceScore(score=0.7, reasoning="Recovered.", evidence=["Checked files"]), LLMUsage(cost_usd=0.1)),
+        ]
+
+        score, usage, initial_errored = run_guidance(
+            config,
+            final_output="done",
+            instructions="test",
+            judge_guidance="Grade holistically.",
+            judge_prompt=None,
+        )
+
+        assert score.score == 0.7
+        assert usage.cost_usd == pytest.approx(0.3)
+        assert initial_errored is True
+        second_retry_guidance = mock_run_guidance_judge.call_args_list[2].args[0].judge_guidance
+        assert '1. Guidance score missing required "Source availability audit" evidence item.' in second_retry_guidance
+        assert '2. Guidance score missing required "Source verification audit" evidence item.' in second_retry_guidance
+        assert "Workspace/artifact check: read /workspace/report.xlsx." in second_retry_guidance
+        assert "Source availability audit: /workspace/orders.csv was accessible." in second_retry_guidance
+
+    @patch("gandalf.orchestrator.run_batch")
+    @patch("gandalf.orchestrator.run_individual")
+    @patch("gandalf.orchestrator.run_guidance_judge")
+    @patch("gandalf.orchestrator.resolve_judge_prompt", return_value=None)
+    @patch("gandalf.orchestrator.resolve_judge_guidance", return_value="Grade holistically.")
+    @patch("gandalf.orchestrator.load_trajectory_final_output", return_value="done")
+    @patch("gandalf.orchestrator.resolve_instructions", return_value="test")
+    @patch("gandalf.orchestrator.load_rubric")
+    @patch("gandalf.orchestrator.load_config")
+    def test_main_guidance_writes_reward_and_info_without_rubric(
+        self,
+        mock_config: Any,
+        mock_load_rubric: Any,
+        mock_instructions: Any,  # noqa: ARG002
+        mock_trajectory: Any,  # noqa: ARG002
+        mock_guidance: Any,  # noqa: ARG002
+        mock_prompt: Any,  # noqa: ARG002
+        mock_run_guidance_judge: Any,
+        mock_run_individual: Any,
+        mock_run_batch: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        output_dir = tmp_path / "output"
+        trajectory = tmp_path / "trajectory.json"
+        trajectory.write_text(json.dumps({"steps": []}))
+        mock_config.return_value = GraderConfig(
+            grading_mode="guidance",
+            instructions="test",
+            judge_guidance="Grade holistically.",
+            workdir=str(tmp_path),
+            trajectory_path=str(trajectory),
+            output_dir=str(output_dir),
+        )
+        mock_run_guidance_judge.return_value = (
+            GuidanceScore(score=0.81234, reasoning="Good result.", evidence=["Checked artifact"]),
+            LLMUsage(cost_usd=0.4, prompt_tokens=12),
+        )
+
+        with patch("sys.argv", ["prog", "--config", "dummy.toml"]):
+            main()
+
+        mock_load_rubric.assert_not_called()
+        mock_run_individual.assert_not_called()
+        mock_run_batch.assert_not_called()
+        reward = json.loads((output_dir / "reward.json").read_text())
+        info = json.loads((output_dir / "info.json").read_text())
+        assert reward == {"reward": 0.8123}
+        assert info["grading_mode"] == "guidance"
+        assert info["reward"] == 0.8123
+        assert info["score"] == 0.8123
+        assert info["reasoning"] == "Good result."
+        assert info["evidence"] == ["Checked artifact"]
+        assert info["llm_usage"]["cost_usd"] == 0.4
+        assert info["errored"] is False
+
+    @patch("gandalf.orchestrator.run_guidance_judge")
+    @patch("gandalf.orchestrator.resolve_judge_prompt", return_value=None)
+    @patch("gandalf.orchestrator.resolve_judge_guidance", return_value="Grade holistically.")
+    @patch("gandalf.orchestrator.load_trajectory_final_output", return_value="done")
+    @patch("gandalf.orchestrator.resolve_instructions", return_value="test")
+    @patch("gandalf.orchestrator.load_config")
+    def test_main_guidance_persistent_failure_writes_info_not_reward(
+        self,
+        mock_config: Any,
+        mock_instructions: Any,  # noqa: ARG002
+        mock_trajectory: Any,  # noqa: ARG002
+        mock_guidance: Any,  # noqa: ARG002
+        mock_prompt: Any,  # noqa: ARG002
+        mock_run_guidance_judge: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        output_dir = tmp_path / "output"
+        trajectory = tmp_path / "trajectory.json"
+        trajectory.write_text(json.dumps({"steps": []}))
+        mock_config.return_value = GraderConfig(
+            grading_mode="guidance",
+            instructions="test",
+            judge_guidance="Grade holistically.",
+            workdir=str(tmp_path),
+            trajectory_path=str(trajectory),
+            output_dir=str(output_dir),
+            judge_retries=1,
+        )
+        mock_run_guidance_judge.return_value = (
+            GuidanceScore(score=None, reasoning="Missing score.", evidence=[]),
+            LLMUsage(cost_usd=0.1),
+        )
+
+        with patch("sys.argv", ["prog", "--config", "dummy.toml"]), pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 1
+
+        info = json.loads((output_dir / "info.json").read_text())
+        assert info["grading_mode"] == "guidance"
+        assert info["reward"] is None
+        assert info["score"] is None
+        assert info["errored"] is True
+        assert "Missing score" in info["error"]
+        assert not (output_dir / "reward.json").exists()
+        assert mock_run_guidance_judge.call_count == 2
 
 
 class TestScoring:

--- a/uv.lock
+++ b/uv.lock
@@ -198,6 +198,18 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncer"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/67/7ea59c3e69eaeee42e7fc91a5be67ca5849c8979acac2b920249760c6af2/asyncer-0.0.8.tar.gz", hash = "sha256:a589d980f57e20efb07ed91d0dbe67f1d2fd343e7142c66d3a099f05c620739c", size = 18217, upload-time = "2024-08-24T23:15:36.449Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/04/15b6ca6b7842eda2748bda0a0af73f2d054e9344320f8bba01f994294bcb/asyncer-0.0.8-py3-none-any.whl", hash = "sha256:5920d48fc99c8f8f0f1576e1882f5022885589c5fcbc46ce4224ec3e53776eeb", size = 9209, upload-time = "2024-08-24T23:15:35.317Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -652,6 +664,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -685,6 +706,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "dspy"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "asyncer" },
+    { name = "cachetools" },
+    { name = "cloudpickle" },
+    { name = "diskcache" },
+    { name = "gepa" },
+    { name = "json-repair" },
+    { name = "litellm" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "orjson" },
+    { name = "pydantic" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "tenacity" },
+    { name = "tqdm" },
+    { name = "typeguard" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/6f/77a79122a16c60b7d5853c11943531bc60f32545369cd05cce4057403a1d/dspy-3.2.1.tar.gz", hash = "sha256:245d6531753cd3e844e7cc47835cfb283c8f57a36a977beabe5034457d9c7241", size = 278428, upload-time = "2026-05-05T19:35:07.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/a1/26ccff78d9e67b17e51fce8ac6d5f57d182ddb20915bf86daf09fc50191a/dspy-3.2.1-py3-none-any.whl", hash = "sha256:4f36c3c0f9d54cd66eeb2a7892df950119e4193deb1fbbc9d46c3438ee1f4df3", size = 331015, upload-time = "2026-05-05T19:35:05.816Z" },
+]
+
+[[package]]
+name = "dspy-ai"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dspy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/9e/e09701f7ac9a9f7dc3d4407eacb022268eb2000b8fcce2e4b76ae08ffafd/dspy_ai-3.2.1.tar.gz", hash = "sha256:d5cb7e0dc1597612a8b49e06f42bc446235e84bd68249fe6adc3287c8184e41b", size = 1220, upload-time = "2026-05-05T19:35:16.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/37/e4dc75151932629a1a9c20f24f7ea83d080f47d6c19c402ebf2b3536dc8e/dspy_ai-3.2.1-py3-none-any.whl", hash = "sha256:613d0ce08d7965fa6ea078df0923c17cfb38489cb3a7300a0a425a54c70ea396", size = 1170, upload-time = "2026-05-05T19:35:15.429Z" },
 ]
 
 [[package]]
@@ -933,6 +995,9 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
 ]
+eval = [
+    { name = "dspy-ai" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -948,6 +1013,16 @@ dev = [
     { name = "mypy", specifier = ">=1.19.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.15.0" },
+]
+eval = [{ name = "dspy-ai", specifier = ">=3.2,<4" }]
+
+[[package]]
+name = "gepa"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/99/6840f84498f2dcbfd27e8a15eeb4e637e84e9dbbd6331977b71f6ffad9c7/gepa-0.0.27.tar.gz", hash = "sha256:02ecb19e4aa6a1f5bb2994cd54b2057f25cd5e8cd662fee514303b2a8ba0a738", size = 155106, upload-time = "2026-01-28T00:33:51.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/bd/f9e83519099a9fd5d090520ab0c51a6278e473b914a9b32d1e812662dd3b/gepa-0.0.27-py3-none-any.whl", hash = "sha256:592beb084fd638d525edae84ca75ad8e9e9c3758e5498b933c17153addf5dd2d", size = 146454, upload-time = "2026-01-28T00:33:50.262Z" },
 ]
 
 [[package]]
@@ -2001,6 +2076,57 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/0a/11486d02add7b1384dff7374d124b1cfbb0ee864dcc9f6a2c0380638cf84/numpy-2.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:489780423903667933b4ed6197b6ec3b75ea5dd17d1d8f0f38d798feb6921561", size = 16789987, upload-time = "2026-06-21T20:56:16.657Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b2/285f48640a181947b4587a3766d21ec1eaa7fea833d4b49957e09da467a2/numpy-2.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ece55976ced6bca95a03ae2839e2e5ccffe8eb6a3e7022415645eb154a81e4e6", size = 11760322, upload-time = "2026-06-21T20:56:19.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/67/b032db1eb03ca30d16eda3b0c22aaa615338b9263c2fd559d0f29451aca4/numpy-2.5.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c83b664b0e6eee9594fa920cf0639d8af796606d3fad6cc70180c87e4b97c7be", size = 5319605, upload-time = "2026-06-21T20:56:22.173Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/83/03fc7300c7c6b6c84c487b1dc80d322817b95fbd1f4dd57a85e23b7198de/numpy-2.5.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:bf80333980bf37f523341ddd72c783f39d6829ec7736b9eb99086388a2d52cc2", size = 6653628, upload-time = "2026-06-21T20:56:23.914Z" },
+    { url = "https://files.pythonhosted.org/packages/82/49/2ec21730bc63ccfda829323f7040a8ed4715b3852ce658689cf74ee96a8c/numpy-2.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1a4874217b36d5ac8fc876f52e39df56f8182c88463e9e2dceabf7ca8b7efb8", size = 15153691, upload-time = "2026-06-21T20:56:25.631Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6b/f4a3d0637692c49da8ef99d72d52526f92e0a8d6ac4f0ca9f31441b9d9ea/numpy-2.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaa760137137e8d3c920d27927748215b56014f92667dc9b6c27dfc61249255a", size = 16660066, upload-time = "2026-06-21T20:56:28.009Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/2f/c354ec86d1f3f5c19649463b0d39652e160736e5b0a4cd18dff0576715c4/numpy-2.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7174ce8265fc7f7417d171c9ea8fe905220748893ea67a2a7abe726ec331c4b0", size = 16514638, upload-time = "2026-06-21T20:56:30.26Z" },
+    { url = "https://files.pythonhosted.org/packages/06/34/43efdcb319988648580f93c11f1ae82cf7e2faa74925e98e454ae3aa95f8/numpy-2.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b8c3daaf99de52415d20b42f8e8155c78642cb04207d02f9d317a0dcf1b3fb54", size = 18419647, upload-time = "2026-06-21T20:56:32.41Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e2/f5d1676b1d7fb682eb5e9a1641e7ebd2414b3216c370661d1029778908b4/numpy-2.5.0-cp312-cp312-win32.whl", hash = "sha256:6206db0af545d73d068add6d992279145f158428d1da6cc49adc4b630c5d6ee5", size = 6056688, upload-time = "2026-06-21T20:56:34.657Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/48f115d1c58a34032facebcd51fdf2d02df2c51d4a46a81dd1197bb2ea6b/numpy-2.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:6f2d6873e2940c860a309d21e25b1e69af6aaffdd80aa056b04c16380db1c4f2", size = 12419237, upload-time = "2026-06-21T20:56:36.24Z" },
+    { url = "https://files.pythonhosted.org/packages/86/26/2e0882f4044d1b1a1b63e875151fb2393389032022a8b7f5657a7996d3b2/numpy-2.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:a55e1eb2bca2cfd17a16b213c99dfc8502d47b0d494224d2122277d0400935ca", size = 10339912, upload-time = "2026-06-21T20:56:38.733Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/07675aaad7f26ea013d5e884d9a0d784b79c6bd7566c333f5a52fa3c610b/numpy-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:520e6b8be0a4b65840ac8090d4f51cef4bed66e2b0894d5a520f099adc24a9b2", size = 16784890, upload-time = "2026-06-21T20:56:40.799Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4b/953118a730ee3b35e28645e0eb4cf9beec5bdbb954e1ac2f5fcefba6bbc3/numpy-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:146b81cdd3967fdb6beca8ba25f00c58741d8f3cbd797f55af0fbe0bfec3469c", size = 11754584, upload-time = "2026-06-21T20:56:43.094Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9b/56dd530c367c74ae17411027cea4135ca57e1e0583bf5594cee18bd83217/numpy-2.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:126b88d95e8ff9b00c9e717aa540469f21d6180162f84c0caec51b16215d49cd", size = 5313904, upload-time = "2026-06-21T20:56:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b0/bcd672edad27ecca7da1f7bb0ce72cd1706a4f2d79ae94990afc97c13e1c/numpy-2.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d4313cef1594c5ce46c31b6e54e918338f63f16ee9322304e8c9114d6d81c8bd", size = 6648504, upload-time = "2026-06-21T20:56:47.567Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9e/15cdfcbd30a1544a46c9e487a00df331c4672450216538705a9e51fa6710/numpy-2.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:750fb097caf26fa878746d9d119f6f9da12dedcbff1eea966c3e3447647c4a9e", size = 15150086, upload-time = "2026-06-21T20:56:49.352Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4e/8d7656ccaab3e81e97258b8a9bc5f0c8502513a92fb4ceb0a2cbfebc17bf/numpy-2.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3893adc2dc7c0412ba76777db55a049215d99c9aa3113003be8f49f4f1290ab9", size = 16647250, upload-time = "2026-06-21T20:56:51.542Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/81/97060281b602ed07f21b12f4ec409eac1f75a2f91fbc829ed8b2becf3ad4/numpy-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:835e454dd99b238cdc5a3f63bce2371296f5ebc53ca1e0f8e6ddbb6d92a29aab", size = 16512864, upload-time = "2026-06-21T20:56:55.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ab/4496208146911f8d8ddb54f68a972aafa6c8d44babcb2ea03b0e5cc87c9d/numpy-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f9836778081a0a3c02a6a21493f3e9f5b311f8d2541934f31f05583dc999ea4", size = 18408407, upload-time = "2026-06-21T20:56:57.75Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9f/a4df67c181e4ee8b467aa3332dc2db10fd5c515136831302f3ca48bc0a01/numpy-2.5.0-cp313-cp313-win32.whl", hash = "sha256:0b525be4744b60bb0557ac872d53ef07d085b5f39622bc579c98d3809d05b988", size = 6054431, upload-time = "2026-06-21T20:57:00.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:44353e2878930039db472b99dc353d749826e4010bd4d2a7f835e94a97a5c748", size = 12414420, upload-time = "2026-06-21T20:57:01.815Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/4a/25c2906f541e9d9f4c5769764db732e6627be91a13f4724fa10634d77db4/numpy-2.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f54b00711f83a5f796b70c518e8c2b3c5848dda03a54911f23eb68519b9b60", size = 10339533, upload-time = "2026-06-21T20:57:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ad/abc44aaceaf7b17ee1edde2bbb4458da591bc79574cffff50c4bb35f00d1/numpy-2.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f27582c55ba4c750b7c58c8faf021d2cd9324a662b466229db8a417b41368af9", size = 16783807, upload-time = "2026-06-21T20:57:06.253Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/39/b72e168daf9c00fb20c9fc996d00437ccecdef3102387775d29d7a62576d/numpy-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:28e7137057d551e4a83c4ae414e3451f50568409db7569aacc7f9811ee06a446", size = 11765215, upload-time = "2026-06-21T20:57:08.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c", size = 5324493, upload-time = "2026-06-21T20:57:11.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/8c/0d104deaa0401c93395a629ec902891618a2eff76d19229139cb5a887bfc/numpy-2.5.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:694d8f74e156f7fd01179f1aa8faa2f648ab6ae0f70b6c3fe57a03249aea2303", size = 6645211, upload-time = "2026-06-21T20:57:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d9/4a4a628c812750363786afc3d33492709a5cd64b215469c16b0f6c7bb811/numpy-2.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7569a7b53c77716f036bb28cb1c91f166a26ec7d9502cd1e4bdfe502fdec22", size = 15166004, upload-time = "2026-06-21T20:57:14.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/2a902317d7fc4aa93236e80c932662dadfc459b323d758329e01775125e1/numpy-2.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a0433bd4086ebd462960cf375e19195bb07b53dc1d87dd5fcf47ad78576f03", size = 16650797, upload-time = "2026-06-21T20:57:16.906Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a0/a0090e6329f4ca5992c07847bb579c5259a19953dc57255bb08793142ffb/numpy-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:929f0c79ac38bcbd7154fe631dc907abfeddbcc5027a896bd1f7767323271e7a", size = 16524647, upload-time = "2026-06-21T20:57:19.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/6caf27734c42b65837e7461ed0dbbd6b6fc835060c9714ec59d673bb383a/numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc4f247a47bbf070bfd70be53ccdcf47b800af563535e7bbe172322197c30e21", size = 18411841, upload-time = "2026-06-21T20:57:21.638Z" },
+    { url = "https://files.pythonhosted.org/packages/13/dc/26edadbd812536769a82c2e9e002234e33feb5da43061d47a044f6d309b7/numpy-2.5.0-cp314-cp314-win32.whl", hash = "sha256:5dc71423499fab3f46f7a7201155ade1669ea101f2f429d332df9e72f8161731", size = 6106361, upload-time = "2026-06-21T20:57:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9e/4dd1459282229a72d92dece2ae9138e5cac94a72263a7ceb48f37434c925/numpy-2.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:ebb81d9d5443e0309d6c54894c3fbed74ad7da0714352a67b6d773cd189eae73", size = 12551749, upload-time = "2026-06-21T20:57:25.945Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a7/6bc6384c080b86c7f6c85c5bc5b540b24f4f679cd144791d99574e90d462/numpy-2.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:3b94d0d0deceebfad3e67ae5c0e5eb87371e8f7a0581cd04a779928c2450cf1e", size = 10617072, upload-time = "2026-06-21T20:57:28.175Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6b/4a2b71d66ada5608ae02b63f150dfad520f6940721cb7f029ad270befc0e/numpy-2.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:22f3d43e362d650bc39db1f17851302874a148ca95ba6981c1dfb5fa6862f35b", size = 11881067, upload-time = "2026-06-21T20:57:30.104Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b2/d365eb40a20efb49d67e9feb90494ed8511282ee1f5fa16006675c65397d/numpy-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:243563efb4cd7528a264567e9fd206c87826457322521d06206a00bfa316c927", size = 5440290, upload-time = "2026-06-21T20:57:32.193Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5e/e9c03188de5f9b767e46a8fe988bcfd3efad066a4a3fda8b9cb11a93f895/numpy-2.5.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:84881d825ca75249b189bbee875fcfe3238aa5c479e6100893cda566e8e86826", size = 6748371, upload-time = "2026-06-21T20:57:33.933Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1d/68c186a38a5027bae2c4ddd5ea681fdaf8b4d30fb7301def6d8ad270390f/numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cda12aa4779d42b8771180aba759c96f527d43446d8f380ab59e2b35e8489efd", size = 15214643, upload-time = "2026-06-21T20:57:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/73f67b7c7e20635baae9c4c3ead4ae7326a005900297a6110971abd62eb5/numpy-2.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c0121101093d2bd74981b10f8837d78e794a8ff57834eb27179f49e1ba11ac6", size = 16690128, upload-time = "2026-06-21T20:57:38.159Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/05/d4c1fb0c46d02a27d6b2b8b319a78c90937acec8631c1641874670b31e6f/numpy-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d371c92cfa09da00022f501ab67fafaea813d752eb30ac44336d45b1e5b0268a", size = 16577902, upload-time = "2026-06-21T20:57:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1d/771c797d50fa26e4888989cccf1d50ee51f530d4e455ad2692dcb64fa711/numpy-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9990713e9c38154c6861e7547f1e3fc7a87e75ff09bab24ef1cc81d81c2835e9", size = 18452814, upload-time = "2026-06-21T20:57:42.875Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
 ]
 
 [[package]]
@@ -6150,6 +6276,18 @@ wheels = [
 ]
 
 [[package]]
+name = "typeguard"
+version = "4.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/53/f701077a29ddf65ed4556119961ef517d767c07f15f6cdf0717ad985426b/typeguard-4.4.3.tar.gz", hash = "sha256:be72b9c85f322c20459b29060c5c099cd733d5886c4ee14297795e62b0c0d59b", size = 75072, upload-time = "2025-06-04T21:47:07.733Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/18/662e2a14fcdbbc9e7842ad801a7f9292fcd6cf7df43af94e59ac9c0da9af/typeguard-4.4.3-py3-none-any.whl", hash = "sha256:7d8b4a3d280257fd1aa29023f22de64e29334bda0b172ff1040f05682223795e", size = 34855, upload-time = "2025-06-04T21:47:03.683Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -6420,6 +6558,119 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
     { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/ed/07e560876a4458987511461187b285071f53cde49dd5b25cd8c51091522b/xxhash-3.8.0.tar.gz", hash = "sha256:d72b2204f37840b0f16f34192c09b994b97bd25823d723d47a1eddfacf06eb43", size = 86107, upload-time = "2026-06-27T08:17:28.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/2e/4b7c3ab28b7a54ac17eae7e02471c49609d6fc5900856a455feeb847a2a3/xxhash-3.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fc4bd14f873cd0b420f6f1ff5b5cd0dbfeb05b044a11bb9345bcbbf9749636e3", size = 34623, upload-time = "2026-06-27T08:13:16.696Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e4/09eea3e1bba6a59d64599cb8fba39f2a0872d06e85420eae989a4da61a9d/xxhash-3.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:31904979198e913239cb61b49f5b849696aeb3b03340da815d1491ec74dcc602", size = 32318, upload-time = "2026-06-27T08:13:18.036Z" },
+    { url = "https://files.pythonhosted.org/packages/01/59/688bbae31e4e2d6d6eb92acbd3837c0e44ff8c7d435e6da922844ff6efda/xxhash-3.8.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7338ad13f2b273a1ef0ea97b2db0a059fdb3a1a29298bfa145937c0e4152d341", size = 220461, upload-time = "2026-06-27T08:13:19.311Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/de/71484ce0dab2fa4a475705d1ebc37a17ff02d40e5df6767b3255cc53120e/xxhash-3.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54e80e803cb34c8a1d278b491e543af40a588d288589c3e6becc991d5328b46b", size = 241110, upload-time = "2026-06-27T08:13:20.844Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f9/1ac88f02e7df7898541490260b21f2b7f7bd2b233038a0cbd3a3b1bffdc2/xxhash-3.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:353953ea18f5c3fbdd13936fb536aacfb47d5bc06eef0919b1a355df61f7cc31", size = 264779, upload-time = "2026-06-27T08:13:22.485Z" },
+    { url = "https://files.pythonhosted.org/packages/25/49/7ea1f128d2fe948ed679020f97a0896cdc6c975da5cc69b53a4a9c4a5def/xxhash-3.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d761f983a315630eff18c2fec7360c6b6946f82748026e779336eb8141ef3eba", size = 242609, upload-time = "2026-06-27T08:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/7d237278dfa1c48722c31010c84a328a317b8885429c8cb6ae4a8fa3e3db/xxhash-3.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f3786a9beb9a3b76241cb7db5f5388b460682c12204236389e3221963fc626a6", size = 473472, upload-time = "2026-06-27T08:13:25.877Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/5f/980fda82620a07d80026b4df371cbca12fca0fd94d7087c4ec5d898da76f/xxhash-3.8.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c94f5a9a775f36cc522fa2a7e8e2cec512e252d2ac056759f753dc68a79ffc", size = 220374, upload-time = "2026-06-27T08:13:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/14/71/efa37bc3e91e1c801972bcef99eab877fcbd17ec10aca16c550ee2951107/xxhash-3.8.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:55ce59f9af37ac861947b43ea3ce7b294b5de77a1234b558d0f07ffad0197624", size = 310220, upload-time = "2026-06-27T08:13:28.804Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/48/19e40320044dc7051e8446505f18557d5661853b87a8770ad399325bb3c8/xxhash-3.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3afa1422a32c7c8e79ad5121dc21eaa5cee9e9e67bffca3f15d15d220d371908", size = 238100, upload-time = "2026-06-27T08:13:30.378Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0d/588499f4d7cd064864ada7adfb9e8785f88a988f1332ed4c1be73d249c15/xxhash-3.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:551fda694938be910529452a89175137c58b4739e41fadff3c047e24b1d74a3b", size = 268937, upload-time = "2026-06-27T08:13:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/54/18/fb2ad593572a33d1b6864b33047b8ca7269273a3c56107b5fd33e0b9c8fb/xxhash-3.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:512eb937c9457e6057e230e005c4709dd2ab63a5989f854d69f31db905750a62", size = 224910, upload-time = "2026-06-27T08:13:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9e/b880f9ed61b73492e24bb962d76aeb63f18ccb895f0edfb52e20d45ed6f2/xxhash-3.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4931ea93840f750a908efebaf23c71004feacc1a4649ef601b96d400a505c9a9", size = 240742, upload-time = "2026-06-27T08:13:35.237Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/89/fc682f93e54e486fc338b26a7d6d0d5cb0ab366269273c2608ac62b51afb/xxhash-3.8.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2fd4b60e8d9fc3923f39079f185b3425e6d76636fcb66d82a33dd7eba7c30f2f", size = 300527, upload-time = "2026-06-27T08:13:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/80/71/a4b4122afb2d17ad69e0922cfeddb5ad5c25b02f37eed3dd3819d42e5f55/xxhash-3.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1da00075f1605794298878cb587f7533329693e2a0c45bbd25d6353644add675", size = 443195, upload-time = "2026-06-27T08:13:38.719Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e5/ed3930f5dc90f4b1bab5ac3be099e8b2e81c1262d85e4adb5f2758e30d23/xxhash-3.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba73801c87d44fa37b2a5feab3004f0a654506027bf032ceb154d94bb74ea772", size = 217252, upload-time = "2026-06-27T08:13:41.179Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ae/128ea5794387ca54bb4084566db20dbdfc9c21cb17b67d3fcb403927b5ba/xxhash-3.8.0-cp312-cp312-win32.whl", hash = "sha256:0b0836dee6022e22ba516ebfa8f76c6e4bda08d6c166c553e40867bac89e4a54", size = 31890, upload-time = "2026-06-27T08:13:42.568Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/04/a6c182dc566c88e8d1a497d22cc4ffdcfcc0a9fa80325efa6cd4b9002c54/xxhash-3.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3bc2a09b98b8f85c75208cd2b2d2aecf40c77ecb2d72f6bf9757db51a98d3499", size = 32677, upload-time = "2026-06-27T08:13:43.705Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b5/aeda4e79f962c8d58ec60cb20a5abfe91c9f7d62e626f69f6659bc0bd0c4/xxhash-3.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:208e6a8b93426896d803224e9fabe26f8b9c651e8381a80b1fa31812faa091e3", size = 29155, upload-time = "2026-06-27T08:13:44.903Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/1f/96f43c5c7c7c4d44721f8d2e5d74698c667a30283c4b10a7e50a56804ee3/xxhash-3.8.0-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:36434c1d1b0a4729df1fa26ab11bffed1ba52666c0beb605c98a995b470cd143", size = 38508, upload-time = "2026-06-27T08:13:46.152Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d9/7d5d6af4876c6481f2e0acb2dda64dd5209574bf7ba1ad4f6af7a1f8d473/xxhash-3.8.0-cp313-cp313-android_21_x86_64.whl", hash = "sha256:a5e6497cefcb2d67f1745c66df9718a99112583af6cc2b70da0312a2eb939f1e", size = 36542, upload-time = "2026-06-27T08:13:47.497Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ff/66fed439d78c5a09a1491a85af29bf8923b516530116731a9ac6b14dee2b/xxhash-3.8.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:5b00b82f1be708da9404fefd658cf5cf3be5ee3be2aae4bfe3b874255badd342", size = 31102, upload-time = "2026-06-27T08:13:48.721Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b8/9fae0399281095f8aca1f32b21947b3c3c75ad6021b255c5c6e4b11d3866/xxhash-3.8.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:38b0cb0ab7f283413b7cace2bf710d7cf8f702ea82cbc683908691d52028a89b", size = 32096, upload-time = "2026-06-27T08:13:50.138Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a4/e53d162c74a8a2950dc063969914387b0680da4c7c20ad17744ec03a3b0a/xxhash-3.8.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:084312171a9798dea85e924b2674f5e1a44933050a1ea1cb1c6b1364e004c66c", size = 34585, upload-time = "2026-06-27T08:13:51.572Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f5/e12397e3f2c4917b6572e103a3277cd27cc56330e304bba61d195d7e5224/xxhash-3.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6a1a9e845bd3bbc57d9356819e0d198fe23282e0576b398a6282a0f8fdc75aef", size = 34622, upload-time = "2026-06-27T08:13:52.818Z" },
+    { url = "https://files.pythonhosted.org/packages/70/80/c053dc51af5c942229689a0e9cb66fdc999bbd840f645e761f5ab73cbb17/xxhash-3.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9ffbde09743ebaf8957b8426948fbe85eab5e5de0d29eec407fcff5a2812a3cc", size = 32320, upload-time = "2026-06-27T08:13:54.04Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a3/294171b67dfe770e1293edcf2a3f7e41302cdb8aefb258585312191b3ffe/xxhash-3.8.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a6dee3952c2b6e82e7f1dbc5dbc6167f9c84126851def7926e32827c2816169c", size = 220532, upload-time = "2026-06-27T08:13:55.448Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c3/d141bfdeca785c8c680abf867d4b52a5e64a55d90df242c3141a3e58c4b2/xxhash-3.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf8ff8e12416c9fa05b43c7509b9332d6ffc4090413c4e7a1dee8599763b6d59", size = 241215, upload-time = "2026-06-27T08:13:57.047Z" },
+    { url = "https://files.pythonhosted.org/packages/09/5a/aeaf35143a6f3d44db73298e861405bdd9c9dacaedfc369cb43d9fd65282/xxhash-3.8.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:cebbb322df4d97d8ef2704f49ed2f6f21f6702fafa0dc0c2a6ae70e904205689", size = 264615, upload-time = "2026-06-27T08:13:58.912Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3e/f8ca782bb34f99693faab70a7989bcc84f62ffe93c9a4cca464a33507a4b/xxhash-3.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9a8d08707b4100ebce598fc59fadf04b42d79b855818d6994f8f0fffd1df8edb", size = 242682, upload-time = "2026-06-27T08:14:00.483Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/ddbee4ff1542c2e88e72269a5a6bd18c3f26a80c2514e0918f5d1f3e9ec5/xxhash-3.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cf5427602dda15d8ce3c6d870d29bf07d43975f59c9d6d3f7f6f93a901b28b12", size = 473551, upload-time = "2026-06-27T08:14:02.17Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f5/a680d48dddab37ab2fd9189ca03f775e29e3627122e30790816d7eb365af/xxhash-3.8.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97d7bd715ea5050b6c9638b52c62adf3055b648ef6eee6892a4cd9697b530191", size = 220485, upload-time = "2026-06-27T08:14:03.765Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b1/7ac129b74981c07f1ff9c649f204465e86f83f9f29b2ebdc70d91514c365/xxhash-3.8.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0cd25bbbab37d898f6e5a90905ce6ae2c1f8bd6668c07cef406fb3e8c8c570dd", size = 310307, upload-time = "2026-06-27T08:14:05.366Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e6/43e673411249dd63f6cd974523a1b32fad75cf5453e363bc8f44af215fb9/xxhash-3.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3e30e5c057f483c3c53a11b53eba091a737cb19dfead36c8b23bf5beb4a169cd", size = 238164, upload-time = "2026-06-27T08:14:07.149Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/95/87f8baf41f63130f3637104b7a610f82b20106332fc6e289c8dbf7955d0e/xxhash-3.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:07dd44d992ebd456752bc25b1c42cd172d94bd8cb24049300449ad0716081c3a", size = 269062, upload-time = "2026-06-27T08:14:08.834Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c9/3369b497cd1f926b930c52fd2400606f177790d887b49f9e86bddcc24562/xxhash-3.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3118600a3102d4707dc1c485dbc3acbbbf37819069ad3e7854e77b923745d76b", size = 225007, upload-time = "2026-06-27T08:14:10.689Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c8/03dceb86a8128858ac105bd6e282d62b3db6fd421a79bd8a9f6b8cdc47a7/xxhash-3.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7ed37b0c95d8fb3fbaad5e13cc0a9727eb8739d1d54b2adef28108c250cada3a", size = 240815, upload-time = "2026-06-27T08:14:12.195Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a5/ebd43eeb1af1dd8f0201943688b20958e99d3f6eb36481fb8c37b55ef139/xxhash-3.8.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:bb043da412e478e7b1db3407051124b85b133803794d3809ad6d92870b304fc7", size = 300632, upload-time = "2026-06-27T08:14:13.916Z" },
+    { url = "https://files.pythonhosted.org/packages/df/24/c873e41a3c00dacc385c8ff08c007723f6a528922c1cea7fd9684e86dae7/xxhash-3.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:196fc132683d9311a0bdce8388ee52bfa07fdc1987cc428a27956e47ccd7b50d", size = 443293, upload-time = "2026-06-27T08:14:15.446Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1b/c671272fe28f70574e3c574d58465f26460154bcc68876121872afa1c14d/xxhash-3.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfb5411af3b77c75e99db100aa15c5ba623c85d72c565e4d7a0ed1a986ff766e", size = 217327, upload-time = "2026-06-27T08:14:17.28Z" },
+    { url = "https://files.pythonhosted.org/packages/57/43/b45a52f795812cb769b6ac159e69b605d18b1c067749e63dcac159e90064/xxhash-3.8.0-cp313-cp313-win32.whl", hash = "sha256:6d1d6179e26830c6690fac63f76d372f69714b977e12ca9c42188a60f51c59f5", size = 31898, upload-time = "2026-06-27T08:14:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/42/2bd70e4eec25dc5990652979d708d4d7c999793d7d5af5d0e48ab4374dc1/xxhash-3.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7c92427a56a12f4d5c7bb26dbb9e9a4658c313ecb6c2f1dca349902e3822df07", size = 32680, upload-time = "2026-06-27T08:14:20.277Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/2fe61edb6144183cf094035a8c5354c65a073127acf6379655ed1e705b70/xxhash-3.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:9fc8453642c1c6d38b4fbac8901c2452ce1fa88b27f003bfee6703cbfae9bd63", size = 29157, upload-time = "2026-06-27T08:14:21.674Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b8/81d17a993b9a4750ba426ce966421681bb4b8e82a460cd346756491b8cc2/xxhash-3.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:efcacb644a915f010dc477447b045e5dcde1afaa40d16b2f0f8e7cd99c9e1635", size = 34897, upload-time = "2026-06-27T08:14:23.044Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3b/f5a368e3273440b3ea58fbd3f0b08c19f552b25ca59f43f5732ca96d2126/xxhash-3.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d1e0dbc510cff94c5efbcc2b82c28b41519fad09b5b1f9f3d99c63e3940e49a0", size = 32630, upload-time = "2026-06-27T08:14:24.603Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ab/f424359c91c55f564fbbe4e454a126eb522471109f67376f20ad19c5e663/xxhash-3.8.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ff19d016a41c90d1f519005887191896b6da1274e1d5d48b347e17eb798ffc5a", size = 225874, upload-time = "2026-06-27T08:14:25.992Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/c2/434579ef9235123b6c9bfa89c5614e0001e988613b91557b24aa326d9faa/xxhash-3.8.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aafc3eab99c50508852e34307e9565933bf128cad084cac7d2471b7ab1743de0", size = 249705, upload-time = "2026-06-27T08:14:27.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6c/3c0c917331ca3c71f826cedce2127f230624e2b49b992472dd5e9e72101c/xxhash-3.8.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5e521368ed79ae6c4d31e1e417726643c49d7d6e286f4fdabf9a8330ed8a8ff7", size = 274716, upload-time = "2026-06-27T08:14:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f3/a8bb98d3307c67e88be9642dff52854c3de3f488f95989b60ff69c8dcc42/xxhash-3.8.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6a0127688d116ec0c225e7e1f744e3f206de2b8822ffeb31a9ab5cc6384f92c5", size = 252019, upload-time = "2026-06-27T08:14:31.247Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/73/fab69a2e5b6353dde643209fe9b6adf4fbd64c888e531deffc476bfb2635/xxhash-3.8.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:22c0b17da2f9fea0f8836538512249871b359141616bad44c58d238b5f011f40", size = 482024, upload-time = "2026-06-27T08:14:32.973Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/ba34099b5278097ec9c68c0b740719813553bfd11ca17e7353de6d2a41e3/xxhash-3.8.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d49465646b1a5e3b1729c5f636e05676a2fb52e203e3b22a5411c416c4c5302", size = 226655, upload-time = "2026-06-27T08:14:34.608Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0c/90aba4708a37fe752b324a7cbf10058eaa33e892cdd62751ff17a5137b93/xxhash-3.8.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c2853dea1e30ed00ca87dd87d76da5da063d302b823b3fb80ccd18421de0f251", size = 319583, upload-time = "2026-06-27T08:14:36.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/46/42e349e2d3017b2688f4cb301742c37c438e77963e3fef711edce2fc5c65/xxhash-3.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:82f0102a2a3760287b7cd7f9e0a30edd4c3b18762ed1a242208d43c8e2bcf30b", size = 246000, upload-time = "2026-06-27T08:14:38.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/15/741b947ae3c768e82018c46846f8616f6aa9b5042649f318a1a6897defe3/xxhash-3.8.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:b8414a66a7524596d841cad5dc1adab6ce76848db5ab2b83db911fbdab1417af", size = 275455, upload-time = "2026-06-27T08:14:39.841Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b4/a9db84c9458fc8f53eaf0051377d1e9eecd9f330fb1225640027417a309d/xxhash-3.8.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0dbaa73df10414ea1e41b98691a9d8241d4c47ad8d02c726587a3cda05278e53", size = 231209, upload-time = "2026-06-27T08:14:41.543Z" },
+    { url = "https://files.pythonhosted.org/packages/20/92/60a868cd34851746d0b0d95dced0f42867c7c00606f6e5dba85b70b232ce/xxhash-3.8.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:43fc9aaba10ab4267c90793601f60d35c3c9caa1544eceb483618a71ad9ce7da", size = 250416, upload-time = "2026-06-27T08:14:43.193Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6a/168ca46a4679c32aae9246caa1fddf35981d6304487e45e992b3d4530324/xxhash-3.8.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ec5eb3d28fbb9802c6d2526f772133a06c91d6f03756fcc67c834b642ffdd51d", size = 309764, upload-time = "2026-06-27T08:14:44.79Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0b/13646b348c07679c818791ab2d35415db5cb20f3bc77daaa255909a401b4/xxhash-3.8.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:2b77c301b644cd9b4d0749a3291081ec2048a6bef7fe0487c993bbba3efb9ce0", size = 448650, upload-time = "2026-06-27T08:14:46.562Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9a/3d244b2acf6bbd86a363817ee09084b4684e8e11840663e19869e9e0d952/xxhash-3.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d7ece11a132325353890a144c30119073617a1299c593ca29b96c315b07e1edd", size = 223572, upload-time = "2026-06-27T08:14:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c7/143410d026a6e0d86dc69037ec2a3b8db810a54e7f443b340ac17612be2e/xxhash-3.8.0-cp313-cp313t-win32.whl", hash = "sha256:b21db84df7b9d54d9e4195a964243c1b32d745c6fbc0cfcfffee1d4bd297196a", size = 32301, upload-time = "2026-06-27T08:14:49.687Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/db/2240b0638161637b2f310231748a7a6a06c79fb43a3adb34c96f359762bf/xxhash-3.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:0643b7d9f598f6da6f1f6b899f4358250d0fb853242e2d712cbde27bf5a99d29", size = 33221, upload-time = "2026-06-27T08:14:51.404Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d8/52038e4fa5baf4f00654a225516168d02908edfec7ca104fbefc58af394f/xxhash-3.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:4bbacf2e938526969f8ab3334d4ac3da14ea059e1dfd1339a92f9091467e750f", size = 29294, upload-time = "2026-06-27T08:14:52.778Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ef/a09907aa28bdcdf6810d5c26656b154c60c0f06bb8db8442a1192d9c227a/xxhash-3.8.0-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:557e2a7cc0b6a634cf9c8e5c975d96b7da796fdeb1824569d760cf0f25b6f33f", size = 38365, upload-time = "2026-06-27T08:14:54.166Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4d/d991ff77bc489c2231025e64e570502156d573c7bff69c917589cc307089/xxhash-3.8.0-cp314-cp314-android_24_x86_64.whl", hash = "sha256:dad744d1613cbfddb844dad93adbffbd51c3e9f53ceea9568f7c3b94bedc19a4", size = 36477, upload-time = "2026-06-27T08:14:55.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0e/553eab001f1e274da73da074968cdc8be8cacfb318937ab9871b8e1909cb/xxhash-3.8.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:953f29b22c04b123cf3cd2e08bccde3a73184aeda5a1038e0054cb3355644120", size = 31116, upload-time = "2026-06-27T08:14:56.897Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d5/d0f4dbe7b4d9ce0125f16e45ec0be5e04f6a172edb4e2fa551c4f2eb5d7a/xxhash-3.8.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:aa699e0253ceffecf41cae858d0a11f2439d6874a0890b556387bffe11dc1c08", size = 32112, upload-time = "2026-06-27T08:14:58.126Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2f/b332c7bede6a676343f2c9c8dea233c8c82753eaeda6f7a2c321d8c58ca3/xxhash-3.8.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e232c82466babc13e956d53aa84d0149660ed6886bc195248bb4d03bf2eca301", size = 34618, upload-time = "2026-06-27T08:14:59.458Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/5b/2bf3c9e61c7cf8f53bce937af45e22b72bb1f224d5afb20352beba0d628d/xxhash-3.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7f75fd1c6a5028f345cd4a8c52f4774d2e5b7809fa58111c60a5502b528914a4", size = 34739, upload-time = "2026-06-27T08:15:00.863Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b6/e88521f5736c181b89bfb7ab756f0ca658a8a1ecece7277b75e167717614/xxhash-3.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b49d7e09b211a1ad658dbe2dbf6561eb92f2e6926bd1101e2d023178371f2d6f", size = 32332, upload-time = "2026-06-27T08:15:02.383Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a2/fba440739fa5f86d2c28738c202e88d3dd063290c8bbb20e183c5334456a/xxhash-3.8.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ceb702bc8e56b7f1f1413d42aa294045b9a0e4c9888e07edc5cd153e8c4c948f", size = 220479, upload-time = "2026-06-27T08:15:03.785Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/1c/4a1639efec16416695d6c7bc6b224d3f607e0b8cbe2409fa81081a849d1c/xxhash-3.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4f3c96e06bdb122e8cc84f5c7088579f3102b828efd62e9dc964a9d17c7b89e", size = 241409, upload-time = "2026-06-27T08:15:05.439Z" },
+    { url = "https://files.pythonhosted.org/packages/92/d1/8ce471f8d6752384f972fd5f6363f2e8d8b867a89fbd724c6dbd91d2bb98/xxhash-3.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:415a8d06ac9bea36b1e06b603a347e0f62401042a97d7bfccec8ae2da12ad784", size = 264433, upload-time = "2026-06-27T08:15:07.027Z" },
+    { url = "https://files.pythonhosted.org/packages/95/77/400a281683fd39c54e2ac497fa67bdf886baaadb8c0ba58f7e1ea1d7692e/xxhash-3.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7f5ccdd2deb5dce31201cc0eec94388cce97e681429073db50903fab0a0a8a0d", size = 242835, upload-time = "2026-06-27T08:15:08.703Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a6/edda651cfa0ba8e921791e93468fae655b63894d89730fcbfe46704f0d0a/xxhash-3.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1a6cf81bc699d3a5ebfcf2fdb2a7bd2e096708d7de193f6f322944a02ba00953", size = 473800, upload-time = "2026-06-27T08:15:10.503Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/da/50f764ec6a93d3961fce294567e41bfca0e66d168deed354a3dc90ebeba6/xxhash-3.8.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4d12a04d7ffc0359f0eadc4535a53cab113044c8d2f262c7e9a56950a5ed50e", size = 220677, upload-time = "2026-06-27T08:15:12.622Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/49/9fe4ed5aac6f38629cc83b34f84748b83ad8295a578ec6a49d8bf896cafb/xxhash-3.8.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d209373fcb66138c652cf843385ee60866e50158a7869bbbf8b322d9a822b765", size = 310385, upload-time = "2026-06-27T08:15:14.384Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f5/1147e03c0553ed22bbae9ce47503c37ee0c5f95592aae10f339c25f61de9/xxhash-3.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b88a3fe28277811e599efa6e1c96abce8a77d60dd79c94da7a9b5c377c172b7b", size = 238330, upload-time = "2026-06-27T08:15:16.201Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d8/92daf66c1966c84da5c97a06ced1480208d3a3bd465cb0630565ec00d1b9/xxhash-3.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5d5a888a5ef997cb35f1aad346eb861cd87ecfe24f5e25d5aa4c9fd1bd3950c2", size = 268667, upload-time = "2026-06-27T08:15:18.064Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c0/080c1a92972667e183c04b03f33c877f8ec61cfa3570e61731077286648d/xxhash-3.8.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:de2836e0329c01555957a603dcd113c337c577081153d691c12a51c5be3282b0", size = 224934, upload-time = "2026-06-27T08:15:19.972Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/d5/cbc4e5b2bee10c94cba05b5bb2b8033e7ef44ae742583fdafcd9188e33ed/xxhash-3.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4bc74eedb0dd5827b3be748bacf9fdb50004037a3e16c7ddb5defae2682cef71", size = 240870, upload-time = "2026-06-27T08:15:22.04Z" },
+    { url = "https://files.pythonhosted.org/packages/76/f7/09679b00e192b741b65c230440c4f7e6df3251a9ad427a518ddf262ec71a/xxhash-3.8.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:c571b03d59e339b010dc84f15a6f1cff80212f3a3116c2a71e2303c95065b1f6", size = 300683, upload-time = "2026-06-27T08:15:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/1b/f43ec36e8c6a20c77be0bcca23f0b133ed8a0312681500d1676eebd71924/xxhash-3.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:87626acdd6e2d762c588a4ffe94258c5ef34fb6049a4a3b25019bdb7f9267a9b", size = 443407, upload-time = "2026-06-27T08:15:25.504Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2e/a3e3a779c5e4789daf975e05cc1c7f11bae724a03855120029d4592c8e63/xxhash-3.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:076d8a4fb290af952826922aa42a46bfc64caa31662ce4e2925a445d0e6ce57f", size = 217559, upload-time = "2026-06-27T08:15:27.234Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/1c1e078ac290afff304a541a2a60965beb369ad65b4f30ec93ea1e0b7210/xxhash-3.8.0-cp314-cp314-win32.whl", hash = "sha256:52f8c7c9833d947e60df830671f6eca810d7c667051243985a561c79f1a3d545", size = 32602, upload-time = "2026-06-27T08:15:28.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/7a/d455cb83d5e3c94046234294fb5dbbe5da600d1bbdf76b9527756920cce9/xxhash-3.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:4fbfcb7dd307e23189a71050f6e27746926590330f37d5fd2ffcb8ea78de1f42", size = 33393, upload-time = "2026-06-27T08:15:30.166Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8f/1b14471f617bc96edbb9566099a162d918a981381c398114726cc600b76c/xxhash-3.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:ecef1e65b4715c7326002073763fe94cc44c756a0698508abb915ab3d6be6e3d", size = 30007, upload-time = "2026-06-27T08:15:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/51ad2f9f784121c8057ef1ba36362f58d4595cbcad16322941f5b73eb53d/xxhash-3.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:02ed856a765cb6e006168595d9455ac8c3c4d60cc04cd47a158a1ac677d68f0f", size = 34957, upload-time = "2026-06-27T08:15:33.292Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/14/175c573ae4fac48bf21a82e5b9ceec75d64c520c51ca08de3105de539438/xxhash-3.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:eec30461a7b457611098ba7ab09363e36c8b2645b4687fb6f3d405bb646e3410", size = 32635, upload-time = "2026-06-27T08:15:34.766Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/f83efabd350a50c31c851b88891e318a6f07bdbf40a43d0f7bb6cedade7f/xxhash-3.8.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b471744912d1ce5dd6d3975b7525e77518359ebf3aa1bd7d501e199f5ae488ea", size = 225969, upload-time = "2026-06-27T08:15:36.35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/78/2b6d12da9cf572c84d93b88ecbf9bf6539a7c5219bde128b214396b97c8b/xxhash-3.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3748d71202bf3f279e77cb8b273b6d0f29d1bcaefb6ce6cb03b95f358863ba37", size = 249851, upload-time = "2026-06-27T08:15:38.087Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/0a/755eeb1882634983b24e6375a95ed233228dc48f0ef12655388bf3c7eeaf/xxhash-3.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3b3bf59ea94b2a23b0f992769804ab9401d5cdcd9df0062fe2cd78a491ae8851", size = 274842, upload-time = "2026-06-27T08:15:39.808Z" },
+    { url = "https://files.pythonhosted.org/packages/77/f2/09b1231cad17c314e51664c4a004c919108ec59aba10f9a28fa061e7b8be/xxhash-3.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:40f061aa5379eba249e9367b179515571e632be6d1b6f55ac139e6fe3d08463c", size = 252218, upload-time = "2026-06-27T08:15:42.105Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/24/de756d55547953494eb6775aea92e258035647b3ecb8547618cd549001e1/xxhash-3.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:680d70896a61fc920cc717a0a8fe8a9fb5858c563184666e31874caa54a16d9e", size = 482135, upload-time = "2026-06-27T08:15:44.476Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/b8147633e32f98ef2b4bb0dfca82f0f63e2b02ff179f20664af64c4216a7/xxhash-3.8.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14973fbdee136588e57447401b521f466a42faca41eecdf35123c73103512ca8", size = 226776, upload-time = "2026-06-27T08:15:46.597Z" },
+    { url = "https://files.pythonhosted.org/packages/29/37/ba051d8f0380d3cf845b23ba058a17d32025846463eb6bf885887fc8effe/xxhash-3.8.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:96c6bca2486cdc58b125966817a92a6abe6ef1fab86b2f8798a7e93488782540", size = 319738, upload-time = "2026-06-27T08:15:48.394Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6f/36e0a27dd27ffa3f7b521650cbcd52a00fb86b71343ffadb642374e8263c/xxhash-3.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0b1109ae238e932d8482f9cb568b56a405cc73bc7a36b837844087f1298dd218", size = 246136, upload-time = "2026-06-27T08:15:50.981Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/73/2663dbf4c09386a9dcc8a94d7a14b4609ed4bad8180ced5b848e60a9b660/xxhash-3.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1da5db0863400eade7c5a31969754d1392189f26b4105f6631da2c6c7ea3bccc", size = 275568, upload-time = "2026-06-27T08:15:52.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/58/f3ce1bc3bb3971191f6521273ddae98d3c610bcefbbed5327c3b3627c12f/xxhash-3.8.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c61b5a0f21ace5e886f177cce43826d85a7c84e35a9e17cb6d1b4ac0b7a7d833", size = 231314, upload-time = "2026-06-27T08:15:54.73Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/51/835706a36cdc00e5b638fba9b22218b3d40d23a7677c923feca8a3f55b98/xxhash-3.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:1db4f27835a450c7e729bc9330c6e702113711cea1f873d646e3a31fe96a9732", size = 250521, upload-time = "2026-06-27T08:15:56.853Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/b0b62caa3caee58ab9de8969f66aef1c3729886f3ff60e173fda3f2762be/xxhash-3.8.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4788a470f946df34383abc6cd345088c13f897a5ee580c4cdd12b1d32ad218ef", size = 309926, upload-time = "2026-06-27T08:15:58.704Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c4/60e6d18a0e131c7af622374af9deede15d3c47d8e5e7221933481b57b319/xxhash-3.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3b6dfa83096cb1e54d082acebaf67f0c42667c56dc48ba536a76cac08d46391e", size = 448812, upload-time = "2026-06-27T08:16:00.619Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9f/c9627daa052be39a932d0e17c6bf6a9041d2cde3afacbded9196acf70261/xxhash-3.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:57ec0ba5299a9a7df376063c139f5826ff0c89b438703939af3d252c31ca96a4", size = 223639, upload-time = "2026-06-27T08:16:02.784Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/38/92916e008a84c1f1a9aef82e4363cdc478a722ff69e59c6afbf93d3d1fda/xxhash-3.8.0-cp314-cp314t-win32.whl", hash = "sha256:d9a61f23b999baeb84102aba767b1b3e94958eab94e6c11b08927e7dc4200795", size = 33078, upload-time = "2026-06-27T08:16:04.639Z" },
+    { url = "https://files.pythonhosted.org/packages/31/7c/e413bc75121d9628bf023b2ed251411ca3a447cf00cd9aa3438ab17f6c67/xxhash-3.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:61069b260fff84116235bb93845f319284dc6b42527c215af59264f4c2ee3468", size = 33953, upload-time = "2026-06-27T08:16:06.347Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/eb/21a96e218375bd8b6ecd6d07cf60c8ff1a046e93cdedc3cf7bc3309edf7b/xxhash-3.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:73cecd431b4f572d38fcf1a7fe85b30eb987778ef9e7a70bc9ffcf2d64810e6f", size = 30164, upload-time = "2026-06-27T08:16:08.009Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a new Gandalf grading-guidance mode alongside the existing rubric mode. Guidance mode runs one holistic judge session against free-form grading guidance, inspects both final artifacts/state and the saved trajectory file, and writes a scalar reward plus detailed info output.

## What changed

- Added `grading_mode = "rubric" | "guidance"` config support while preserving rubric behavior as the default.
- Added guidance-mode judge input/output models, score parsing, validation, retries, and info/reward output handling.
- Added a guidance judge template with required artifact, trajectory, source availability, source verification, side-effect, output-location, score-calibration, and source/guidance conflict audit instructions.
- Added guidance evidence helpers so runtime validation and analysis share the same evidence semantics.
- Added Harbor rollout/evaluation helper scripts and DSPy calibration scripts for offline comparison and prompt iteration.
- Added README and quickstart examples for guidance mode.
- Added test coverage for models, config validation, judge parsing, orchestration, prompt requirements, Harbor scripts, evidence heuristics, and retry behavior.

## Safety and compatibility

- Rubric mode remains the default and keeps its existing output schema.
- Guidance mode rejects rubric/batch-only fields to avoid silently ignoring configured rubrics.
- The trajectory is copied into the cloned judge workspace and referenced by path instead of being inlined into the judge prompt.
- The PR branch is a single clean commit based on `origin/main`; exploratory local commits were not pushed.
- I scanned the final staged diff for local user paths and real-looking secrets. Hard-coded local `/Users/...` paths were replaced with `$HOME` / `Path.home()` defaults.

## Validation

- `uv run pytest` -> 488 passed, 3 deselected
- `uvx hatch run types:check` -> no issues found in 13 source files
- `uvx hatch fmt --check` -> all checks passed, 18 files already formatted
