### PR TITLE
Update Gemini quickstart model

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cat examples/quickstart/output/info.json     # per-criterion verdicts + reasonin
 
 Expected verdicts: the `welcome.txt` file exists (met), the message mentions Gandalf (met), and the message is *not* longer than 50 words (unmet, by design). Raw score 3.0 of a possible 4.0, for a reward of 0.75.
 
-The example uses [`gemini/gemini-2.5-flash`](examples/quickstart/grader.toml) and runs the inner judge as the current user (no `sandbox_user`, no sudo). To adapt it to your own setup, edit [`examples/quickstart/grader.toml`](examples/quickstart/grader.toml). See the [Configuration](#configuration) section below for the full field reference.
+The example uses [`gemini/gemini-3.5-flash`](examples/quickstart/grader.toml) and runs the inner judge as the current user (no `sandbox_user`, no sudo). To adapt it to your own setup, edit [`examples/quickstart/grader.toml`](examples/quickstart/grader.toml). See the [Configuration](#configuration) section below for the full field reference.
 
 ## Configuration
 
@@ -78,7 +78,7 @@ The example uses [`gemini/gemini-2.5-flash`](examples/quickstart/grader.toml) an
 | `workdir` | Yes | | Agent workspace directory |
 | `trajectory_path` | Yes | | Path to ATIF trajectory JSON |
 | `output_dir` | Yes | | Directory for grader output files |
-| `model` | No | `gemini/gemini-2.5-flash` | LLM model for the judge agent |
+| `model` | No | `gemini/gemini-3.5-flash` | LLM model for the judge agent |
 | `mode` | No | `batch` | Evaluation mode: `batch` or `individual` |
 | `judge_timeout` | No | `300` | Max seconds per judge invocation |
 | `batch_timeout` | No | | Max total seconds for batch mode (caps `judge_timeout * N`) |

--- a/examples/quickstart/grader.toml
+++ b/examples/quickstart/grader.toml
@@ -9,10 +9,10 @@
 # - `sandbox_user` is intentionally omitted so the inner judge runs as the
 #   current user. For production setups, configure a dedicated sandbox user
 #   (see the Configuration section of the README).
-# - `model` is any litellm-compatible identifier. `gemini/gemini-2.5-flash`
+# - `model` is any litellm-compatible identifier. `gemini/gemini-3.5-flash`
 #   requires `LLM_API_KEY` (a Gemini API key) in your environment.
 
-model = "gemini/gemini-2.5-flash"
+model = "gemini/gemini-3.5-flash"
 instructions = "Write a friendly welcome message to a text file in the workspace."
 rubric_path = "examples/quickstart/rubric.json"
 workdir = "examples/quickstart/workspace"


### PR DESCRIPTION
## Summary

- update the quick-start configuration from `gemini/gemini-2.5-flash` to `gemini/gemini-3.5-flash`
- keep the README's quick-start and configuration references aligned

## Why

For a new Gemini API user, the documented `gemini-2.5-flash` example returned:

> This model models/gemini-2.5-flash is no longer available to new users.

This prevented the published quick-start from completing.

## Validation

- ran `gandalf-the-grader --config examples/quickstart/grader.toml` with the updated model
- all three criteria evaluated successfully
- observed the expected documented reward: `0.75` (`3.0 / 4.0`)
- `git diff --check` passes
