### PR TITLE
Add workspace_is_disposable to skip the workspace clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `workspace_is_disposable` config option. When the caller guarantees the workspace is a
+  throwaway that nothing reads after grading, and that `sandbox_user` can already read and
+  write it, the judge runs against it directly instead of a clone. Saves a full copy of the
+  workspace, which on a large one is the difference between grading and running out of disk.
+  Rejected in combination with concurrent judge sessions, which would share the workspace.
+
 ## [1.0.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The example uses [`gemini/gemini-2.5-flash`](examples/quickstart/grader.toml) an
 | `judge_retries` | No | `1` | Number of retry attempts for criteria that error due to infrastructure failures |
 | `batch_splits` | No | | Split criteria into N chunks in batch mode (>= 2). Each chunk is evaluated as a separate batch session. Only valid with `mode = "batch"`. |
 | `max_concurrency` | No | | Max parallel judge sessions (>= 1). Defaults to 1 for individual mode, `batch_splits` for batch mode. |
+| `workspace_is_disposable` | No | `false` | Grade `workdir` directly instead of cloning it. Only set this when nothing reads the workspace after grading and `sandbox_user` can already read and write it — the judge writes to the tree it is grading. Cannot be combined with concurrent judge sessions. |
 | `sandbox_user` | No | | Username for running the inner judge (via sudo). When omitted the judge runs as the current user. |
 | `judge_prompt` | No | | Inline Jinja2 template that completely overrides the built-in judge task prompt (mutually exclusive with `judge_prompt_path`) |
 | `judge_prompt_path` | No | | Path to a Jinja2 template file that completely overrides the built-in judge task prompt (mutually exclusive with `judge_prompt`) |

--- a/src/gandalf/models.py
+++ b/src/gandalf/models.py
@@ -70,6 +70,22 @@ class GraderConfig(BaseModel):
     In batch mode the effective timeout per session is
     ``judge_timeout * n_criteria_in_session``, optionally capped by
     batch_timeout.
+
+    workspace_is_disposable is the caller's assertion that workdir is a throwaway
+    copy which nothing will read after grading, and that sandbox_user can already
+    read and write it.  When set, the judge runs against workdir directly instead
+    of a clone.
+
+    The clone normally earns its cost twice over: it makes the tree accessible to
+    sandbox_user, and it keeps the judge's writes off the artifact being graded.
+    A caller that has already satisfied both is paying a full copy of the
+    workspace for nothing, which on a large workspace is the difference between
+    grading and running out of disk.
+
+    It is an assertion rather than something detected here because it is not a
+    property of the filesystem.  Whether anyone still needs the original is a
+    fact about the caller's environment, and a grader that guessed would silently
+    drop isolation for callers grading in a live workspace.
     """
 
     model: str = "gemini/gemini-2.5-flash"
@@ -92,6 +108,7 @@ class GraderConfig(BaseModel):
     batch_splits: int | None = Field(default=None, ge=2)
     max_concurrency: int | None = Field(default=None, ge=1)
     judge_retries: int = 1
+    workspace_is_disposable: bool = False
 
     @model_validator(mode="after")
     def _check_no_inline_and_path(self) -> "GraderConfig":
@@ -113,7 +130,34 @@ class GraderConfig(BaseModel):
         if self.batch_splits is not None and self.mode != "batch":
             msg = "'batch_splits' can only be used with mode='batch'"
             raise ValueError(msg)
+        if self.workspace_is_disposable and self.runs_concurrent_judges:
+            # Each session normally gets its own clone, so parallel judges never meet.
+            # Without one they would share a working directory and a HOME, and overwrite
+            # each other's scratch files mid-run — a wrong verdict, not a crash. Refuse
+            # the combination rather than silently cloning anyway, which would restore
+            # correctness while quietly spending the disk the caller opted out of.
+            msg = (
+                "'workspace_is_disposable' cannot be combined with concurrent judge "
+                "sessions: parallel judges would share one workspace. Set "
+                "max_concurrency=1, or drop 'workspace_is_disposable'."
+            )
+            raise ValueError(msg)
         return self
+
+    @property
+    def runs_concurrent_judges(self) -> bool:
+        """Whether more than one judge session can be in flight at once.
+
+        Mirrors how ``main`` resolves concurrency, so the two cannot disagree about
+        whether sessions overlap.
+        """
+        if self.mode == "batch":
+            if self.batch_splits is None:
+                return False
+            concurrency = self.max_concurrency if self.max_concurrency is not None else self.batch_splits
+        else:
+            concurrency = self.max_concurrency or 1
+        return concurrency > 1
 
 
 class _BaseJudgeInput(BaseModel):

--- a/src/gandalf/orchestrator.py
+++ b/src/gandalf/orchestrator.py
@@ -246,8 +246,15 @@ def run_judge(
     sandbox_user: str | None,
     trace_path: str,
     timeout: int = 300,
+    *,
+    workspace_is_disposable: bool = False,
 ) -> tuple[list[Verdict], LLMUsage]:
-    """Clone workspace, run the judge subprocess, and return parsed verdicts.
+    """Run the judge subprocess against the workspace and return parsed verdicts.
+
+    The workspace is normally cloned first — see ``clone_workspace``.  When
+    ``workspace_is_disposable`` the caller has guaranteed both of the things the
+    clone provides, so the judge runs against ``judge_input.workdir`` itself and a
+    full copy of the workspace is not made.  See ``GraderConfig``.
 
     Always returns a *list* of verdicts, even for a single-criterion
     ``JudgeInput`` (one-element list).  On any subprocess failure every
@@ -259,19 +266,37 @@ def run_judge(
     def fail(msg: str) -> tuple[list[Verdict], LLMUsage]:
         return Verdict.errors(n, msg), LLMUsage()
 
-    try:
-        clone_dir = clone_workspace(judge_input.workdir)
-    except Exception as e:  # noqa: BLE001
-        return fail(f"Failed to clone workspace: {e}")
+    if workspace_is_disposable:
+        workdir = judge_input.workdir
+        # The judge's scratch files still need somewhere world-writable to live, and it
+        # is not the workspace: these are the grader's own plumbing, and writing them
+        # into the tree under evaluation puts the criteria list in front of the judge as
+        # if it were part of the agent's work, and leaves them behind in anything that
+        # later inspects the graded tree.
+        try:
+            scratch_dir = tempfile.mkdtemp(prefix="judge_scratch_")
+            os.chmod(scratch_dir, 0o777)  # noqa: S103
+        except OSError as e:
+            return fail(f"Failed to create judge scratch directory: {e}")
+    else:
+        try:
+            workdir = clone_workspace(judge_input.workdir)
+        except Exception as e:  # noqa: BLE001
+            return fail(f"Failed to clone workspace: {e}")
+        scratch_dir = workdir
 
-    cloned_input = judge_input.model_copy(update={"workdir": clone_dir})
+    # Removing the clone removes its scratch files with it; a borrowed workspace must
+    # outlive the run, so only the scratch directory is ours to delete.
+    cleanup_dir = scratch_dir if workspace_is_disposable else workdir
+
+    cloned_input = judge_input.model_copy(update={"workdir": workdir})
 
     prefix = "judge_batch_" if batch else "judge_"
     with tempfile.NamedTemporaryFile(
         mode="w",
         suffix=".json",
         prefix=f"{prefix}input_",
-        dir=clone_dir,
+        dir=scratch_dir,
         delete=False,
     ) as input_f:
         input_f.write(cloned_input.model_dump_json())
@@ -283,7 +308,7 @@ def run_judge(
         mode="w",
         suffix=".json",
         prefix=f"{prefix}output_",
-        dir=clone_dir,
+        dir=scratch_dir,
         delete=False,
     ) as output_f:
         output_path = output_f.name
@@ -291,7 +316,9 @@ def run_judge(
 
     try:
         os.chmod(input_path, 0o644)
-        env_vars = [f"HOME={clone_dir}", *judge_env_vars()]
+        # HOME tracks the working directory in both modes, so a judge that resolves
+        # tooling through HOME behaves the same whether or not the workspace was cloned.
+        env_vars = [f"HOME={workdir}", *judge_env_vars()]
 
         cmd = []
         if sandbox_user is not None:
@@ -314,7 +341,7 @@ def run_judge(
             capture_output=True,
             text=True,
             timeout=timeout,
-            cwd=clone_dir,
+            cwd=workdir,
         )
 
         save_trace(trace_path, result.stdout, result.stderr, result.returncode)
@@ -338,7 +365,7 @@ def run_judge(
         usage = LLMUsage.model_validate(data["llm_usage"])
         return verdicts, usage
     finally:
-        shutil.rmtree(clone_dir, ignore_errors=True)
+        shutil.rmtree(cleanup_dir, ignore_errors=True)
 
 
 def save_trace(trace_path: str, stdout: str, stderr: str, returncode: int) -> None:
@@ -406,6 +433,7 @@ def run_individual(
             sandbox_user=config.sandbox_user,
             trace_path=trace_path,
             timeout=config.judge_timeout,
+            workspace_is_disposable=config.workspace_is_disposable,
         )
         result = verdict_to_result(item, verdicts[0])
         print(f"  [{i + 1}/{n}] {format_status(met=verdicts[0].met)}: {verdicts[0].reasoning[:120]}")  # noqa: T201
@@ -471,6 +499,7 @@ def run_batch(
         sandbox_user=config.sandbox_user,
         trace_path=trace_path,
         timeout=batch_timeout,
+        workspace_is_disposable=config.workspace_is_disposable,
     )
 
     results: list[CriterionResult] = []
@@ -545,6 +574,7 @@ def run_batch_concurrent(
             sandbox_user=config.sandbox_user,
             trace_path=trace_path,
             timeout=batch_timeout,
+            workspace_is_disposable=config.workspace_is_disposable,
         )
 
         indexed_results: list[tuple[int, CriterionResult]] = []

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -640,3 +640,74 @@ class TestGraderConfigMode:
         cfg = self._cfg(mode="individual", max_concurrency=4)
         assert cfg.max_concurrency == 4
         assert cfg.batch_splits is None
+
+
+class TestWorkspaceIsDisposable:
+    """Validate the opt-out from cloning the workspace before grading."""
+
+    _DEFAULTS: ClassVar[dict[str, Any]] = {
+        "instructions": "test",
+        "rubric_path": "/rubric.json",
+        "workdir": "/workspace",
+        "trajectory_path": "/logs/trajectory.json",
+        "output_dir": "/logs/grader",
+    }
+
+    def _cfg(self, **overrides: Any) -> GraderConfig:
+        return GraderConfig(**{**self._DEFAULTS, **overrides})
+
+    def test_defaults_to_cloning(self) -> None:
+        """Isolation is the default; giving it up has to be asked for."""
+        assert self._cfg().workspace_is_disposable is False
+
+    def test_accepted_for_a_single_session(self) -> None:
+        assert self._cfg(workspace_is_disposable=True).workspace_is_disposable is True
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"mode": "individual", "max_concurrency": 2},
+            {"mode": "batch", "batch_splits": 2},
+            {"mode": "batch", "batch_splits": 4, "max_concurrency": 2},
+        ],
+    )
+    def test_rejected_when_judges_would_share_the_workspace(self, overrides: dict[str, Any]) -> None:
+        """Without a clone per session, parallel judges collide in one directory —
+        a wrong verdict rather than a crash, so refuse instead of grading."""
+        with pytest.raises(ValidationError, match="concurrent judge"):
+            self._cfg(workspace_is_disposable=True, **overrides)
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"mode": "batch"},
+            {"mode": "batch", "batch_splits": 4, "max_concurrency": 1},
+            {"mode": "individual"},
+            {"mode": "individual", "max_concurrency": 1},
+        ],
+    )
+    def test_allowed_whenever_sessions_run_one_at_a_time(self, overrides: dict[str, Any]) -> None:
+        assert self._cfg(workspace_is_disposable=True, **overrides).workspace_is_disposable is True
+
+    def test_concurrency_is_unconstrained_while_cloning(self) -> None:
+        """The restriction belongs to the opt-out, not to concurrency itself."""
+        assert self._cfg(mode="batch", batch_splits=4).runs_concurrent_judges is True
+
+    @pytest.mark.parametrize(
+        ("overrides", "expected"),
+        [
+            ({"mode": "batch"}, False),
+            ({"mode": "batch", "batch_splits": 3}, True),
+            ({"mode": "batch", "batch_splits": 3, "max_concurrency": 1}, False),
+            ({"mode": "individual"}, False),
+            ({"mode": "individual", "max_concurrency": 3}, True),
+        ],
+    )
+    def test_reports_whether_sessions_overlap(self, overrides: dict[str, Any], expected: bool) -> None:
+        """Mirrors how `main` resolves concurrency, so the two cannot disagree."""
+        assert self._cfg(**overrides).runs_concurrent_judges is expected
+
+    def test_unknown_keys_are_ignored(self) -> None:
+        """A grader older than the config that sets this key must still run: the flag is
+        an optimisation, and refusing to start would make rollout order load-bearing."""
+        assert self._cfg(some_future_flag=True).workdir == "/workspace"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1075,6 +1075,120 @@ class TestRetryLogic:
         assert reward["reward"] == info["reward"]
 
 
+class TestDisposableWorkspace:
+    """Tests for grading a workspace directly instead of cloning it."""
+
+    @patch("gandalf.orchestrator.clone_workspace")
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_does_not_clone(self, mock_run: Any, mock_clone: Any, tmp_path: pathlib.Path) -> None:
+        """The whole point: no copy of the workspace is made."""
+        mock_run.side_effect = make_run_writing({"verdicts": [], "llm_usage": {}})
+        run_judge(
+            make_batch_input(tmp_path, n=1),
+            sandbox_user="sandbox",
+            trace_path=str(tmp_path / "trace.txt"),
+            workspace_is_disposable=True,
+        )
+        mock_clone.assert_not_called()
+
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_judge_runs_in_the_workspace_itself(self, mock_run: Any, tmp_path: pathlib.Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        judge_input = make_batch_input(workspace, n=1)
+        mock_run.side_effect = make_run_writing({"verdicts": [], "llm_usage": {}})
+
+        run_judge(
+            judge_input,
+            sandbox_user="sandbox",
+            trace_path=str(tmp_path / "trace.txt"),
+            workspace_is_disposable=True,
+        )
+
+        _cmd, kwargs = mock_run.call_args
+        assert kwargs["cwd"] == str(workspace)
+
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_home_tracks_the_working_directory(self, mock_run: Any, tmp_path: pathlib.Path) -> None:
+        """A judge that resolves tooling through HOME must behave the same either way."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        mock_run.side_effect = make_run_writing({"verdicts": [], "llm_usage": {}})
+
+        run_judge(
+            make_batch_input(workspace, n=1),
+            sandbox_user="sandbox",
+            trace_path=str(tmp_path / "trace.txt"),
+            workspace_is_disposable=True,
+        )
+
+        cmd = mock_run.call_args[0][0]
+        assert f"HOME={workspace}" in cmd
+
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_scratch_files_stay_out_of_the_graded_tree(self, mock_run: Any, tmp_path: pathlib.Path) -> None:
+        """Grader plumbing in the workspace would show the judge the criteria list as if
+        it were part of the agent's work, and survive into whatever inspects the tree."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        mock_run.side_effect = make_run_writing({"verdicts": [], "llm_usage": {}})
+
+        run_judge(
+            make_batch_input(workspace, n=1),
+            sandbox_user="sandbox",
+            trace_path=str(tmp_path / "trace.txt"),
+            workspace_is_disposable=True,
+        )
+
+        cmd = mock_run.call_args[0][0]
+        for flag in ("--input", "--output"):
+            path = pathlib.Path(cmd[cmd.index(flag) + 1])
+            assert workspace not in path.parents
+        assert list(workspace.iterdir()) == []
+
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_workspace_survives_the_run(self, mock_run: Any, tmp_path: pathlib.Path) -> None:
+        """A borrowed workspace is not ours to delete — only a clone is."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "deliverable.md").write_text("the work")
+        mock_run.side_effect = make_run_writing({"verdicts": [], "llm_usage": {}})
+
+        run_judge(
+            make_batch_input(workspace, n=1),
+            sandbox_user="sandbox",
+            trace_path=str(tmp_path / "trace.txt"),
+            workspace_is_disposable=True,
+        )
+
+        assert (workspace / "deliverable.md").read_text() == "the work"
+
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_scratch_directory_is_removed(self, mock_run: Any, tmp_path: pathlib.Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        mock_run.side_effect = make_run_writing({"verdicts": [], "llm_usage": {}})
+
+        run_judge(
+            make_batch_input(workspace, n=1),
+            sandbox_user="sandbox",
+            trace_path=str(tmp_path / "trace.txt"),
+            workspace_is_disposable=True,
+        )
+
+        scratch = pathlib.Path(mock_run.call_args[0][0][mock_run.call_args[0][0].index("--input") + 1]).parent
+        assert not scratch.exists()
+
+    @patch("gandalf.orchestrator.clone_workspace")
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_clones_by_default(self, mock_run: Any, mock_clone: Any, tmp_path: pathlib.Path) -> None:
+        """Isolation stays the default; skipping it must be asked for."""
+        mock_clone.return_value = str(tmp_path)
+        mock_run.side_effect = make_run_writing({"verdicts": [], "llm_usage": {}})
+        run_judge(make_batch_input(tmp_path, n=1), sandbox_user="sandbox", trace_path=str(tmp_path / "t.txt"))
+        mock_clone.assert_called_once()
+
+
 class TestCloneWorkspace:
     """Tests for clone_workspace resilience to unreadable files."""
 


### PR DESCRIPTION
## Summary

Every judge session begins by copying the whole workspace. `clone_workspace` earns that cost twice over: it makes the tree accessible to `sandbox_user`, and it keeps the judge's writes off the artifact being graded.

A caller that has already satisfied both is paying a full copy of the workspace for nothing. On a multi-gigabyte workspace that copy is the difference between grading and running out of disk — and it is spent on a workspace that will be discarded either way.

This adds `workspace_is_disposable` so such a caller can say so.

## Behaviour

When set, the judge runs against `workdir` itself — same `cwd`, and `HOME` still tracks the working directory so a judge that resolves tooling through `HOME` behaves identically either way.

Two details are deliberate:

**Scratch files stay out of the graded tree.** `judge_input_*.json` and the pre-created output file go to a separate temp directory. Writing them into the workspace would put the criteria list in front of the judge as if it were part of the agent's work, and leave them behind in anything that later inspects the tree.

**Only the scratch directory is removed.** Removing a clone removes its scratch files with it, but a borrowed workspace must outlive the run — it is not ours to delete.

## Why an assertion rather than detection

Whether the workspace is disposable is not a property of the filesystem. `os.access` can tell you the tree is writable; it cannot tell you whether anything still needs the original afterwards. That is a fact about the caller's environment, and a grader that inferred it from writability would silently drop isolation for callers grading in a live workspace — the case the clone exists for.

So the caller declares the lifecycle and the grader decides the mechanism. The default is unchanged.

## Refused with concurrent sessions

`workspace_is_disposable` with `max_concurrency > 1` (or `batch_splits` without a concurrency cap) raises at config-validation time.

Each session normally gets its own clone, so parallel judges never meet. Without one they would share a working directory and a `HOME`, and overwrite each other's scratch files mid-run — which produces a wrong verdict, not a crash. Cloning anyway would restore correctness while quietly spending the disk the caller opted out of, so this fails loudly instead.

The check reads concurrency through a `runs_concurrent_judges` property that mirrors how `main` resolves it, so the two cannot disagree about whether sessions overlap.

## Compatibility

Additive and default-off. `GraderConfig` does not set `extra="forbid"`, so a grader older than the config that sets this key ignores it and clones as before — rollout order is not load-bearing. There is a test for that.

## Tests

```bash
hatch test
```

259 pass. New coverage: that no clone is made; that `cwd` and `HOME` are the workspace; that scratch files land outside the graded tree and the tree is left empty; that the workspace survives the run while the scratch directory does not; that cloning remains the default; the validator's accept/reject matrix; and the concurrency-resolution table.

Mutation-checked — pointing cleanup at the borrowed workspace instead of the scratch directory (the dangerous regression: deleting the work being graded) fails three of the new tests.

`ruff check` clean; `ruff format --check --line-length 120` reports no change against this repo's settings.

## Context

The motivating case: verifier sandboxes in our RL-environment pipeline are clones of the rollout sandbox, dedicated to one grade and discarded immediately after. The workspace there is already a throwaway copy that `sandbox_user` can read and write, so the clone is a second redundant copy of a home that can be several GB — enough to exhaust the sandbox disk during grading while the rollout itself fit comfortably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
