### PR TITLE
Fix Windows judge launch when sandbox_user is omitted

### DIFF
--- a/src/gandalf/models.py
+++ b/src/gandalf/models.py
@@ -172,12 +172,32 @@ class Verdict(BaseModel):
     @classmethod
     def from_raw(cls, data: dict[str, Any]) -> "Verdict":
         """Create a Verdict from a raw JSON-parsed dict, normalizing types."""
-        raw_met = data.get("met")
         return cls(
-            met=bool(raw_met) if raw_met is not None else None,
+            met=cls._coerce_met(data.get("met")),
             reasoning=str(data.get("reasoning", "No reasoning provided.")),
             evidence=list(data.get("evidence", [])),
         )
+
+    @staticmethod
+    def _coerce_met(raw_met: Any) -> bool | None:
+        """Normalize a raw ``met`` value.
+
+        LLMs sometimes write JSON booleans as strings. ``bool("false")`` is
+        True, which would flip an unmet criterion to met — so strings are
+        parsed explicitly instead of being truthiness-coerced.
+        """
+        if raw_met is None:
+            return None
+        if isinstance(raw_met, bool):
+            return raw_met
+        if isinstance(raw_met, str):
+            lowered = raw_met.strip().lower()
+            if lowered in {"true", "1", "yes"}:
+                return True
+            if lowered in {"false", "0", "no"}:
+                return False
+            return None
+        return bool(raw_met)
 
     @classmethod
     def errors(cls, n: int, reason: str) -> list["Verdict"]:

--- a/src/gandalf/orchestrator.py
+++ b/src/gandalf/orchestrator.py
@@ -291,14 +291,23 @@ def run_judge(
 
     try:
         os.chmod(input_path, 0o644)
-        env_vars = [f"HOME={clone_dir}", *judge_env_vars()]
+        home_and_allowlist = [f"HOME={clone_dir}", *judge_env_vars()]
 
-        cmd = []
+        cmd: list[str] = []
+        run_env: dict[str, str] | None = None
         if sandbox_user is not None:
-            cmd += ["sudo", "-u", sandbox_user]
+            # sudo resets the environment; env(1) re-injects the allowlisted vars.
+            cmd += ["sudo", "-u", sandbox_user, "env", *home_and_allowlist]
+        else:
+            # Overlay HOME + allowlist onto the current environment. Equivalent to
+            # `env KEY=VAL cmd` without `-i`, and does not require Unix env(1)
+            # (which is not on PATH on Windows).
+            run_env = os.environ.copy()
+            for item in home_and_allowlist:
+                key, _, value = item.partition("=")
+                run_env[key] = value
+
         cmd += [
-            "env",
-            *env_vars,
             "gandalf-the-grader-judge",
             "--input",
             input_path,
@@ -308,13 +317,19 @@ def run_judge(
         if batch:
             cmd.append("--batch")
 
-        result = subprocess.run(
+        # CreateProcess on Windows appends .exe and ignores PATHEXT, so a
+        # gandalf-the-grader-judge.cmd stub on PATH is skipped in favor of an
+        # installed .exe. cmd.exe honors PATHEXT, which is what we need here.
+        use_shell = sys.platform == "win32" and sandbox_user is None
+        result = subprocess.run(  # noqa: S602
             cmd,
             check=False,
             capture_output=True,
             text=True,
             timeout=timeout,
             cwd=clone_dir,
+            env=run_env,
+            shell=use_shell,
         )
 
         save_trace(trace_path, result.stdout, result.stderr, result.returncode)

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -258,6 +258,19 @@ class TestReadVerdict:
         result = read_verdict(str(p))
         assert result.met is None
 
+    def test_string_false_is_not_met(self, tmp_path: pathlib.Path) -> None:
+        """bool('false') is True; a string false from the judge must stay unmet."""
+        p = tmp_path / "verdict.json"
+        p.write_text(json.dumps({"met": "false", "reasoning": "not present", "evidence": []}))
+        result = read_verdict(str(p))
+        assert result.met is False
+
+    def test_string_true_is_met(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "verdict.json"
+        p.write_text(json.dumps({"met": "true", "reasoning": "present", "evidence": []}))
+        result = read_verdict(str(p))
+        assert result.met is True
+
     def test_empty_file(self, tmp_path: pathlib.Path) -> None:
         p = tmp_path / "verdict.json"
         p.write_text("")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -246,6 +246,22 @@ class TestPydanticModels:
         restored = Verdict.model_validate_json(raw)
         assert restored.met is None
 
+    def test_from_raw_bool_met(self) -> None:
+        assert Verdict.from_raw({"met": True, "reasoning": "ok"}).met is True
+        assert Verdict.from_raw({"met": False, "reasoning": "no"}).met is False
+
+    def test_from_raw_string_false_is_unmet(self) -> None:
+        v = Verdict.from_raw({"met": "false", "reasoning": "missing"})
+        assert v.met is False
+
+    def test_from_raw_string_true_is_met(self) -> None:
+        v = Verdict.from_raw({"met": "True", "reasoning": "present"})
+        assert v.met is True
+
+    def test_from_raw_null_met_stays_none(self) -> None:
+        v = Verdict.from_raw({"met": None, "reasoning": "errored"})
+        assert v.met is None
+
     def test_criterion_result(self) -> None:
         r = CriterionResult(
             criterion="test",

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import sys
 import threading
 import time
 from collections.abc import Callable
@@ -38,6 +39,15 @@ from gandalf.orchestrator import (
     write_info,
 )
 from tests.conftest import cr, make_batch_input, make_config
+
+requires_posix_permissions = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX permission bits are not enforced for the file owner on Windows",
+)
+requires_symlinks = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Creating symlinks requires SeCreateSymbolicLinkPrivilege on Windows",
+)
 
 
 class TestResolveInstructions:
@@ -491,20 +501,8 @@ class TestEvaluateAllCriteria:
         assert usage == LLMUsage()
 
 
-@pytest.fixture
-def fake_judge(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
-    """Create a fake ``gandalf-the-grader-judge`` on PATH.
-
-    The script reads --input/--output args and writes a valid verdict to the
-    output file.  When ``--batch`` is passed it writes the dict-with-verdicts
-    format; otherwise a single-criterion verdict dict.
-    """
-    script = tmp_path / "bin" / "gandalf-the-grader-judge"
-    script.parent.mkdir()
-    script.write_text(
-        """\
-#!/usr/bin/env python3
-import argparse, json, sys
+_FAKE_JUDGE_PY = """\
+import argparse, json
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--input", required=True)
@@ -525,10 +523,29 @@ else:
 
 with open(args.output, "w") as f:
     json.dump(result, f)
-""",
-    )
-    script.chmod(0o755)
-    monkeypatch.setenv("PATH", f"{script.parent}:{os.environ.get('PATH', '')}")
+"""
+
+
+@pytest.fixture
+def fake_judge(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    """Create a fake ``gandalf-the-grader-judge`` on PATH.
+
+    The script reads --input/--output args and writes a valid verdict to the
+    output file.  When ``--batch`` is passed it writes the dict-with-verdicts
+    format; otherwise a single-criterion verdict dict.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    if sys.platform == "win32":
+        impl = bin_dir / "_fake_judge.py"
+        impl.write_text(_FAKE_JUDGE_PY, encoding="utf-8")
+        script = bin_dir / "gandalf-the-grader-judge.cmd"
+        script.write_text(f'@echo off\r\n"{sys.executable}" "{impl}" %*\r\n', encoding="utf-8")
+    else:
+        script = bin_dir / "gandalf-the-grader-judge"
+        script.write_text("#!/usr/bin/env python3\n" + _FAKE_JUDGE_PY, encoding="utf-8")
+        script.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
     return script
 
 
@@ -570,6 +587,34 @@ class TestSandboxUserNone:
         assert len(verdicts) == 2
         assert all(v.met is True for v in verdicts)
         assert usage.cost_usd == 0.01
+
+    @patch("gandalf.orchestrator.clone_workspace")
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_no_sudo_invokes_judge_directly(self, mock_run: Any, mock_clone: Any, tmp_path: pathlib.Path) -> None:
+        """Without sandbox_user, do not shell out to Unix env(1) or sudo."""
+        mock_clone.return_value = str(tmp_path)
+        mock_run.side_effect = make_run_writing(
+            {
+                "verdict": {"met": True, "reasoning": "ok", "evidence": []},
+                "llm_usage": {"cost_usd": 0},
+            }
+        )
+        judge_input = JudgeInput(
+            model="test-model",
+            instructions="test",
+            final_output="done",
+            criterion="check something",
+            workdir=str(tmp_path),
+        )
+        run_judge(judge_input, sandbox_user=None, trace_path=str(tmp_path / "trace.txt"))
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "gandalf-the-grader-judge"
+        assert "env" not in cmd
+        assert "sudo" not in cmd
+        env = mock_run.call_args.kwargs["env"]
+        assert env is not None
+        assert env["HOME"] == str(tmp_path)
 
 
 class TestScoring:
@@ -1092,6 +1137,7 @@ class TestCloneWorkspace:
         finally:
             shutil.rmtree(clone_dir, ignore_errors=True)
 
+    @requires_posix_permissions
     def test_unreadable_files_are_skipped_not_fatal(self, tmp_path: pathlib.Path) -> None:
         workspace = tmp_path / "workspace"
         workspace.mkdir()
@@ -1110,6 +1156,7 @@ class TestCloneWorkspace:
             restricted.chmod(0o644)
             shutil.rmtree(clone_dir, ignore_errors=True)
 
+    @requires_posix_permissions
     def test_skipped_files_are_logged(self, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
         workspace = tmp_path / "workspace"
         workspace.mkdir()
@@ -1126,6 +1173,7 @@ class TestCloneWorkspace:
             restricted.chmod(0o644)
             shutil.rmtree(clone_dir, ignore_errors=True)
 
+    @requires_posix_permissions
     def test_unreadable_directory_is_skipped_not_fatal(self, tmp_path: pathlib.Path) -> None:
         workspace = tmp_path / "workspace"
         workspace.mkdir()
@@ -1147,6 +1195,7 @@ class TestCloneWorkspace:
             restricted_dir.chmod(0o755)
             shutil.rmtree(clone_dir, ignore_errors=True)
 
+    @requires_posix_permissions
     def test_unreadable_directory_is_logged(self, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
         workspace = tmp_path / "workspace"
         workspace.mkdir()
@@ -1219,6 +1268,7 @@ class TestCloneWorkspace:
         finally:
             shutil.rmtree(clone_dir, ignore_errors=True)
 
+    @requires_posix_permissions
     def test_executable_bits_are_preserved(self, tmp_path: pathlib.Path) -> None:
         """Cloned files must retain execute bits so scripts/binaries remain runnable."""
         workspace = tmp_path / "workspace"
@@ -1245,6 +1295,7 @@ class TestCloneWorkspace:
         finally:
             shutil.rmtree(clone_dir, ignore_errors=True)
 
+    @requires_symlinks
     def test_broken_symlink_is_skipped_not_fatal(self, tmp_path: pathlib.Path) -> None:
         """A broken symlink in the workspace must be skipped, not crash the clone.
 
@@ -1265,6 +1316,7 @@ class TestCloneWorkspace:
         finally:
             shutil.rmtree(clone_dir, ignore_errors=True)
 
+    @requires_symlinks
     def test_symlink_to_directory_is_skipped_not_fatal(self, tmp_path: pathlib.Path) -> None:
         """A symlink-to-directory in filenames must be skipped, not crash the clone.
 
@@ -1288,6 +1340,7 @@ class TestCloneWorkspace:
         finally:
             shutil.rmtree(clone_dir, ignore_errors=True)
 
+    @requires_symlinks
     def test_symlink_loop_is_skipped_not_fatal(self, tmp_path: pathlib.Path) -> None:
         """Circular symlinks in the workspace must be skipped, not crash the clone."""
         workspace = tmp_path / "workspace"


### PR DESCRIPTION
## Summary

I was trying to run the grader on Windows without sandbox_user (same as the quickstart). Even in that path the orchestrator was still calling the Unix `env` command. On Windows `env` is not on PATH, so subprocess fails immediately and the inner judge never starts.

Because of this I have changed the no-sudo path to pass HOME and the allowlisted variables through the subprocess environment instead of shelling out to `env`. On Windows I also start that process via `cmd`, because CreateProcess only looks for `.exe` and ignores `.cmd` stubs on PATH.

There is one more issue in the same area: if the judge writes met: false` as a string, Python treats `bool(false)` as True. So an unmet criterion can silently get marked as met. I am now parsing true/false strings properly.

## Why this is needed

Without this change, anyone running Gandalf on native Windows cannot use the documented no-sudo quickstart at all. The string-boolean bug can also inflate the reward.

## How I tested

I ran `hatch test --include python=3.12` locally on Windows. The no-sudo tests pass with a `.cmd` launcher. POSIX permission and symlink clone tests are skipped on Windows, which is expected.

## Notes

This PR is only this fix. Other Windows issues are in separate PRs so they can be reviewed independently.