### PR TITLE
Allow Windows quickstart without tmux, reject sandbox_user there

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ uv tool install 'gandalf-the-grader[pinned]==1.0.0'
 
 ## Runtime dependencies
 
-**Important**: Gandalf is built on top of OpenHands, which [works best](https://github.com/OpenHands/software-agent-sdk/pull/120) when `tmux` is installed. The judge refuses to run when `tmux` is not on `PATH` rather than silently falling back to a less stable subprocess-based terminal.
+**Important**: Gandalf is built on top of OpenHands, which [works best](https://github.com/OpenHands/software-agent-sdk/pull/120) when `tmux` is installed. On Linux and macOS the judge refuses to run when `tmux` is not on `PATH` rather than silently falling back to a less stable subprocess-based terminal.
+
+Native Windows has no `tmux`. The grader warns and continues so the quickstart can run, using OpenHands' subprocess terminal. For production grading, run under WSL or Linux. `sandbox_user` is also Linux-only: it launches the inner judge with `sudo`, which Windows does not provide. Omit `sandbox_user` (the quickstart already does) to run the judge as the current user.
 
 ## Quick start
 
@@ -85,7 +87,7 @@ The example uses [`gemini/gemini-2.5-flash`](examples/quickstart/grader.toml) an
 | `judge_retries` | No | `1` | Number of retry attempts for criteria that error due to infrastructure failures |
 | `batch_splits` | No | | Split criteria into N chunks in batch mode (>= 2). Each chunk is evaluated as a separate batch session. Only valid with `mode = "batch"`. |
 | `max_concurrency` | No | | Max parallel judge sessions (>= 1). Defaults to 1 for individual mode, `batch_splits` for batch mode. |
-| `sandbox_user` | No | | Username for running the inner judge (via sudo). When omitted the judge runs as the current user. |
+| `sandbox_user` | No | | Username for running the inner judge via sudo (Linux only). When omitted the judge runs as the current user. Not supported on Windows. |
 | `judge_prompt` | No | | Inline Jinja2 template that completely overrides the built-in judge task prompt (mutually exclusive with `judge_prompt_path`) |
 | `judge_prompt_path` | No | | Path to a Jinja2 template file that completely overrides the built-in judge task prompt (mutually exclusive with `judge_prompt`) |
 

--- a/src/gandalf/orchestrator.py
+++ b/src/gandalf/orchestrator.py
@@ -658,11 +658,23 @@ def check_tmux_available() -> None:
     """Verify tmux is installed and usable.
 
     OpenHands silently falls back to a less stable subprocess-based terminal
-    when tmux is missing; we refuse to run in that mode.
+    when tmux is missing; on POSIX we refuse to run in that mode.
+
+    Native Windows has no tmux. We warn and continue so the quickstart can
+    run; production grading should use WSL or Linux.
 
     Raises:
-        RuntimeError: If tmux is missing or cannot be run.
+        RuntimeError: If tmux is missing or cannot be run on POSIX.
     """
+    if sys.platform == "win32":
+        print(  # noqa: T201
+            "Warning: tmux is not available on native Windows. "
+            "OpenHands will use its subprocess terminal, which is less stable. "
+            "For production grading, run under WSL or Linux.",
+            file=sys.stderr,
+        )
+        return
+
     # Same probe as OpenHands terminal factory (_is_tmux_available): run tmux and
     # require exit 0. OpenHands silently falls back to a subprocess terminal
     # when this fails; we fail fast instead.
@@ -682,9 +694,26 @@ def check_tmux_available() -> None:
         raise RuntimeError(msg)
 
 
-def preflight_check() -> None:
+def check_sandbox_user_supported(sandbox_user: str | None) -> None:
+    """Reject sandbox_user on platforms that have no sudo.
+
+    Raises:
+        RuntimeError: If sandbox_user is set on Windows.
+    """
+    if sandbox_user is None:
+        return
+    if sys.platform == "win32":
+        msg = (
+            "sandbox_user requires sudo, which is not available on Windows. "
+            "Omit sandbox_user to run the judge as the current user, or run under WSL."
+        )
+        raise RuntimeError(msg)
+
+
+def preflight_check(sandbox_user: str | None = None) -> None:
     """Validate runtime prerequisites before doing any real work."""
     check_tmux_available()
+    check_sandbox_user_supported(sandbox_user)
 
 
 def main() -> None:
@@ -692,9 +721,8 @@ def main() -> None:
     parser.add_argument("--config", required=True, help="Path to grader config TOML file")
     args = parser.parse_args()
 
-    preflight_check()
-
     config = load_config(args.config)
+    preflight_check(sandbox_user=config.sandbox_user)
 
     instructions = resolve_instructions(config)
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -24,6 +24,7 @@ from gandalf.models import (
 )
 from gandalf.orchestrator import (
     JUDGE_ENV_ALLOWLIST,
+    check_sandbox_user_supported,
     check_tmux_available,
     clone_workspace,
     judge_env_vars,
@@ -318,12 +319,16 @@ class TestCheckTmuxAvailable:
 
     def test_passes_when_tmux_runs_successfully(self) -> None:
         ok = subprocess.CompletedProcess(args=["tmux", "-V"], returncode=0, stdout="tmux 3.3a\n", stderr="")
-        with patch("gandalf.orchestrator.subprocess.run", return_value=ok):
+        with (
+            patch("gandalf.orchestrator.sys.platform", "linux"),
+            patch("gandalf.orchestrator.subprocess.run", return_value=ok),
+        ):
             check_tmux_available()  # does not raise
 
     def test_raises_on_nonzero_returncode(self) -> None:
         bad = subprocess.CompletedProcess(args=["tmux", "-V"], returncode=1, stdout="", stderr="broken")
         with (
+            patch("gandalf.orchestrator.sys.platform", "linux"),
             patch("gandalf.orchestrator.subprocess.run", return_value=bad),
             pytest.raises(RuntimeError, match="tmux"),
         ):
@@ -331,13 +336,24 @@ class TestCheckTmuxAvailable:
 
     def test_raises_when_tmux_not_found(self) -> None:
         with (
+            patch("gandalf.orchestrator.sys.platform", "linux"),
             patch("gandalf.orchestrator.subprocess.run", side_effect=FileNotFoundError),
             pytest.raises(RuntimeError, match="tmux"),
         ):
             check_tmux_available()
 
+    def test_windows_warns_and_skips_probe(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("gandalf.orchestrator.sys.platform", "win32"),
+            patch("gandalf.orchestrator.subprocess.run") as mock_run,
+        ):
+            check_tmux_available()  # does not raise
+        mock_run.assert_not_called()
+        assert "WSL" in capsys.readouterr().err
+
     def test_raises_on_timeout(self) -> None:
         with (
+            patch("gandalf.orchestrator.sys.platform", "linux"),
             patch(
                 "gandalf.orchestrator.subprocess.run",
                 side_effect=subprocess.TimeoutExpired(cmd="tmux", timeout=5.0),
@@ -348,18 +364,48 @@ class TestCheckTmuxAvailable:
 
     def test_invokes_tmux_dash_v(self) -> None:
         ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with patch("gandalf.orchestrator.subprocess.run", return_value=ok) as mock_run:
+        with (
+            patch("gandalf.orchestrator.sys.platform", "linux"),
+            patch("gandalf.orchestrator.subprocess.run", return_value=ok) as mock_run,
+        ):
             check_tmux_available()
         assert mock_run.call_args[0][0] == ["tmux", "-V"]
+
+
+class TestCheckSandboxUserSupported:
+    def test_none_is_always_ok(self) -> None:
+        check_sandbox_user_supported(None)
+
+    def test_rejects_sandbox_user_on_windows(self) -> None:
+        with (
+            patch("gandalf.orchestrator.sys.platform", "win32"),
+            pytest.raises(RuntimeError, match="sudo"),
+        ):
+            check_sandbox_user_supported("sandbox")
+
+    def test_allows_sandbox_user_on_linux(self) -> None:
+        with patch("gandalf.orchestrator.sys.platform", "linux"):
+            check_sandbox_user_supported("sandbox")
 
 
 class TestPreflightCheck:
     """preflight_check is the single entry point for runtime prerequisites."""
 
     def test_calls_check_tmux_available(self) -> None:
-        with patch("gandalf.orchestrator.check_tmux_available") as mock_check:
+        with (
+            patch("gandalf.orchestrator.check_tmux_available") as mock_check,
+            patch("gandalf.orchestrator.check_sandbox_user_supported"),
+        ):
             preflight_check()
         mock_check.assert_called_once_with()
+
+    def test_passes_sandbox_user_through(self) -> None:
+        with (
+            patch("gandalf.orchestrator.check_tmux_available"),
+            patch("gandalf.orchestrator.check_sandbox_user_supported") as mock_sandbox,
+        ):
+            preflight_check(sandbox_user="sandbox")
+        mock_sandbox.assert_called_once_with("sandbox")
 
     def test_propagates_check_failure(self) -> None:
         with (


### PR DESCRIPTION
## Summary

On native Windows, `tmux` is not available. Preflight was treating that as a hard failure, so `gandalf-the-grader` could not even start. OpenHands can still run using its subprocess terminal (less stable, but usable for local/quickstart). So on Windows I now print a warning and continue. Linux and macOS still require tmux, same as before.

Separately, `sandbox_user` is implemented with `sudo`. Windows does not have sudo. If someone sets `sandbox_user` on Windows, we were going to call sudo and fail in a confusing way. I now fail in preflight with a clear message: omit `sandbox_user`, or run under WSL.

I have also updated the README runtime section to explain this.

## Why this is needed

The published quickstart omits `sandbox_user` and is the path Windows users will try first. Blocking the whole CLI only because tmux is missing makes the tool look broken. sudo sandboxing was never going to work on Windows anyway, so we should say so up front.

## How I tested

Unit tests for the tmux probe (including the Windows skip), sandbox_user rejection on Windows, and preflight wiring. `hatch test --include python=3.12` for those classes.

## Notes

This is independent of the judge-launch PR. Production grading should still use WSL or Linux with tmux.