### PR TITLE
Fix missing-judge error message, evidence strings, and UTF-8 IO

### DIFF
--- a/src/gandalf/judge.py
+++ b/src/gandalf/judge.py
@@ -41,7 +41,9 @@ def render_template(
     If *judge_prompt* is provided (a raw Jinja2 template string),
     it is used instead of the built-in template identified by *template_name*.
     """
-    template_str = judge_prompt if judge_prompt is not None else (TEMPLATES_DIR / template_name).read_text()
+    template_str = (
+        judge_prompt if judge_prompt is not None else (TEMPLATES_DIR / template_name).read_text(encoding="utf-8")
+    )
     rendered: str = jinja2.Template(template_str).render(**variables)
     return rendered
 
@@ -93,7 +95,7 @@ def build_batch_judge_prompt(
 def read_verdict(verdict_path: str) -> Verdict:
     """Read and validate the verdict file written by the judge agent."""
     try:
-        with open(verdict_path) as f:
+        with open(verdict_path, encoding="utf-8") as f:
             content = f.read().strip()
         if not content:
             return Verdict(met=None, reasoning="Judge agent wrote an empty verdict file.")
@@ -114,7 +116,7 @@ def read_batch_verdict(verdict_path: str, n_criteria: int) -> list[Verdict]:
     indices get a default fail verdict.
     """
     try:
-        with open(verdict_path) as f:
+        with open(verdict_path, encoding="utf-8") as f:
             content = f.read().strip()
         if not content:
             return Verdict.errors(
@@ -261,7 +263,7 @@ def run_agent_session(
 
 def run_judge(input_path: str, output_path: str) -> None:
     """Run the agent-as-judge for a single rubric criterion."""
-    with open(input_path) as f:
+    with open(input_path, encoding="utf-8") as f:
         judge_input = JudgeInput.model_validate_json(f.read())
 
     verdict_path = make_verdict_path(prefix="verdict_", directory=judge_input.workdir)
@@ -286,7 +288,7 @@ def run_judge(input_path: str, output_path: str) -> None:
             os.unlink(verdict_path)
 
     output = {"verdict": verdict.model_dump(), "llm_usage": llm_usage.model_dump()}
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(output, f)
 
 
@@ -300,7 +302,7 @@ def run_judge_batch(input_path: str, output_path: str) -> None:
     verdict objects, one per criterion index) and ``llm_usage`` (aggregate
     token/cost dict for the session).
     """
-    with open(input_path) as f:
+    with open(input_path, encoding="utf-8") as f:
         judge_input = BatchJudgeInput.model_validate_json(f.read())
 
     n_criteria = len(judge_input.criteria)
@@ -333,7 +335,7 @@ def run_judge_batch(input_path: str, output_path: str) -> None:
         "verdicts": TypeAdapter(list[Verdict]).dump_python(verdicts),
         "llm_usage": llm_usage.model_dump(),
     }
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(output, f, indent=2)
 
 

--- a/src/gandalf/models.py
+++ b/src/gandalf/models.py
@@ -176,8 +176,25 @@ class Verdict(BaseModel):
         return cls(
             met=bool(raw_met) if raw_met is not None else None,
             reasoning=str(data.get("reasoning", "No reasoning provided.")),
-            evidence=list(data.get("evidence", [])),
+            evidence=cls._coerce_evidence(data.get("evidence", [])),
         )
+
+    @staticmethod
+    def _coerce_evidence(raw: Any) -> list[str]:
+        """Normalize evidence to a list of strings.
+
+        If the judge writes evidence as a single string instead of a JSON
+        array, ``list(that_string)`` would split it into characters. We keep
+        the string as one evidence item instead.
+        """
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            text = raw.strip()
+            return [text] if text else []
+        if isinstance(raw, list):
+            return [str(item) for item in raw]
+        return [str(raw)]
 
     @classmethod
     def errors(cls, n: int, reason: str) -> list["Verdict"]:

--- a/src/gandalf/orchestrator.py
+++ b/src/gandalf/orchestrator.py
@@ -45,7 +45,7 @@ from gandalf.models import (
 
 def load_trajectory_final_output(path: str) -> str:
     """Load an ATIF trajectory file and extract the final agent message."""
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         data = json.load(f)
 
     steps = data.get("steps", [])
@@ -109,7 +109,7 @@ def resolve_optional_file(
             file=sys.stderr,
         )
         sys.exit(1)
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return f.read()
 
 
@@ -269,6 +269,7 @@ def run_judge(
     prefix = "judge_batch_" if batch else "judge_"
     with tempfile.NamedTemporaryFile(
         mode="w",
+        encoding="utf-8",
         suffix=".json",
         prefix=f"{prefix}input_",
         dir=clone_dir,
@@ -281,6 +282,7 @@ def run_judge(
     # needing general write access to /tmp (which may not be world-writable).
     with tempfile.NamedTemporaryFile(
         mode="w",
+        encoding="utf-8",
         suffix=".json",
         prefix=f"{prefix}output_",
         dir=clone_dir,
@@ -308,21 +310,24 @@ def run_judge(
         if batch:
             cmd.append("--batch")
 
-        result = subprocess.run(
-            cmd,
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            cwd=clone_dir,
-        )
+        try:
+            result = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=clone_dir,
+            )
+        except FileNotFoundError as e:
+            return fail(f"Judge executable not found: {e}")
 
         save_trace(trace_path, result.stdout, result.stderr, result.returncode)
 
         if result.returncode != 0:
             return fail(f"Judge process failed (exit {result.returncode}): {result.stderr[:500]}")
 
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             data = json.load(f)
 
     except subprocess.TimeoutExpired:
@@ -343,7 +348,7 @@ def run_judge(
 
 def save_trace(trace_path: str, stdout: str, stderr: str, returncode: int) -> None:
     """Write the judge's stdout/stderr to a trace file."""
-    with contextlib.suppress(OSError), open(trace_path, "w") as f:
+    with contextlib.suppress(OSError), open(trace_path, "w", encoding="utf-8") as f:
         f.write(f"exit_code: {returncode}\n")
         f.write("=== stdout ===\n")
         f.write(stdout)
@@ -648,7 +653,7 @@ def write_info(
         errored_criterion_count=errored_criterion_count,
         evaluated_criteria_pct=evaluated_pct,
     )
-    with open(os.path.join(config.output_dir, "info.json"), "w") as f:
+    with open(os.path.join(config.output_dir, "info.json"), "w", encoding="utf-8") as f:
         f.write(info.model_dump_json(indent=2))
 
     return reward, raw_score
@@ -679,6 +684,10 @@ def check_tmux_available() -> None:
         ok = False
     if not ok:
         msg = "tmux is not installed or not on PATH."
+        if sys.platform == "win32":
+            msg += (
+                " Gandalf needs tmux for the OpenHands terminal and does not run on native Windows; use WSL or Linux."
+            )
         raise RuntimeError(msg)
 
 
@@ -760,7 +769,7 @@ def main() -> None:
         sys.exit(1)
 
     # 6. All resolved — write reward.json
-    with open(os.path.join(config.output_dir, "reward.json"), "w") as f:
+    with open(os.path.join(config.output_dir, "reward.json"), "w", encoding="utf-8") as f:
         json.dump({"reward": reward}, f, indent=2)
 
     print(f"\nReward: {reward} (raw: {raw_score})")  # noqa: T201

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -258,6 +258,12 @@ class TestReadVerdict:
         result = read_verdict(str(p))
         assert result.met is None
 
+    def test_string_evidence_is_not_split(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "verdict.json"
+        p.write_text(json.dumps({"met": True, "reasoning": "ok", "evidence": "checked foo.txt"}))
+        result = read_verdict(str(p))
+        assert result.evidence == ["checked foo.txt"]
+
     def test_empty_file(self, tmp_path: pathlib.Path) -> None:
         p = tmp_path / "verdict.json"
         p.write_text("")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -246,6 +246,14 @@ class TestPydanticModels:
         restored = Verdict.model_validate_json(raw)
         assert restored.met is None
 
+    def test_from_raw_string_evidence_is_not_split(self) -> None:
+        v = Verdict.from_raw({"met": True, "reasoning": "ok", "evidence": "checked foo.txt"})
+        assert v.evidence == ["checked foo.txt"]
+
+    def test_from_raw_null_evidence_is_empty(self) -> None:
+        v = Verdict.from_raw({"met": True, "reasoning": "ok", "evidence": None})
+        assert v.evidence == []
+
     def test_criterion_result(self) -> None:
         r = CriterionResult(
             criterion="test",

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -336,6 +336,14 @@ class TestCheckTmuxAvailable:
         ):
             check_tmux_available()
 
+    def test_windows_error_mentions_wsl(self) -> None:
+        with (
+            patch("gandalf.orchestrator.sys.platform", "win32"),
+            patch("gandalf.orchestrator.subprocess.run", side_effect=FileNotFoundError),
+            pytest.raises(RuntimeError, match="WSL"),
+        ):
+            check_tmux_available()
+
     def test_raises_on_timeout(self) -> None:
         with (
             patch(
@@ -447,6 +455,24 @@ class TestEvaluateAllCriteria:
         assert len(verdicts) == 2
         assert all(v.met is None for v in verdicts)
         assert "timed out" in verdicts[0].reasoning.lower()
+        assert usage == LLMUsage()
+
+    @patch("gandalf.orchestrator.clone_workspace")
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_missing_executable_is_not_read_error(self, mock_run: Any, mock_clone: Any, tmp_path: pathlib.Path) -> None:
+        """A missing judge binary must not be reported as a failed output read."""
+        mock_clone.return_value = str(tmp_path)
+        mock_run.side_effect = FileNotFoundError("gandalf-the-grader-judge")
+
+        judge_input = make_batch_input(tmp_path, n=2)
+        trace_path = str(tmp_path / "trace.txt")
+
+        verdicts, usage = run_judge(judge_input, sandbox_user="sandbox", trace_path=trace_path)
+
+        assert len(verdicts) == 2
+        assert all(v.met is None for v in verdicts)
+        assert "executable not found" in verdicts[0].reasoning.lower()
+        assert "read judge output" not in verdicts[0].reasoning.lower()
         assert usage == LLMUsage()
 
     @patch("gandalf.orchestrator.clone_workspace")


### PR DESCRIPTION
## Summary

Three related correctness issues, all in how we read judge output.

First: if gandalf-the-grader-judge is not on PATH, subprocess raises FileNotFoundError. That exception was caught together with JSON parse errors, so the user sees "Failed to read judge output". That is misleading because the output file was never the problem. I have split this and now report "Judge executable not found".

Second: sometimes the judge writes evidence as a single string instead of a JSON array. The old code did list(evidence), which splits the string into characters. For example, "checked foo.txt" becomes one character per item. I am now keeping a string as one evidence item, and treating null as an empty list.

Third: text files were opened without an encoding. On Windows the default encoding is not UTF-8, so verdict JSON, traces, and info.json can get corrupted. All text reads/writes in the grader now use UTF-8.

## Why this is needed

Wrong error text makes debugging much harder. Character-split evidence is wrong in info.json. Encoding issues are easy to miss until someone hits non-ASCII paths or reasoning text on Windows.

## How I tested

hatch test --include python=3.12 for the model, judge, and orchestrator cases covering missing executable and string evidence.

## Notes

This PR does not change how the judge process is launched. That is a separate PR.
