### PR TITLE
Skip malformed ATIF trajectory shapes instead of crashing

### DIFF
--- a/src/gandalf/orchestrator.py
+++ b/src/gandalf/orchestrator.py
@@ -48,14 +48,21 @@ def load_trajectory_final_output(path: str) -> str:
     with open(path) as f:
         data = json.load(f)
 
+    if not isinstance(data, dict):
+        return ""
+
     steps = data.get("steps", [])
+    if not isinstance(steps, list):
+        return ""
 
     # Extract final agent message (last with non-empty content, no tool calls)
     final_output = ""
     for step in reversed(steps):
+        if not isinstance(step, dict):
+            continue
         if step.get("source") == "agent" and not step.get("tool_calls"):
             msg = step.get("message", "")
-            if msg.strip():
+            if isinstance(msg, str) and msg.strip():
                 final_output = msg
                 break
 

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -81,3 +81,41 @@ class TestLoadTrajectoryFinalOutput:
         p = tmp_path / "user_only.json"
         p.write_text(json.dumps({"steps": [{"source": "user", "message": "hello"}]}))
         assert load_trajectory_final_output(str(p)) == ""
+
+    def test_non_object_json_returns_empty(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "array.json"
+        p.write_text(json.dumps([{"source": "agent", "message": "hi"}]))
+        assert load_trajectory_final_output(str(p)) == ""
+
+    def test_steps_not_a_list_returns_empty(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "bad_steps.json"
+        p.write_text(json.dumps({"steps": {"source": "agent", "message": "hi"}}))
+        assert load_trajectory_final_output(str(p)) == ""
+
+    def test_skips_non_dict_steps(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "mixed_steps.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "steps": [
+                        "not a step",
+                        {"source": "agent", "message": "Here is the result."},
+                    ]
+                }
+            )
+        )
+        assert load_trajectory_final_output(str(p)) == "Here is the result."
+
+    def test_non_string_message_is_skipped(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "non_string_msg.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "steps": [
+                        {"source": "agent", "message": {"text": "nope"}},
+                        {"source": "agent", "message": "Here is the result."},
+                    ]
+                }
+            )
+        )
+        assert load_trajectory_final_output(str(p)) == "Here is the result."


### PR DESCRIPTION
## Summary

I hit this while feeding the grader a trajectory that was not a clean ATIF object. `load_trajectory_final_output` assumes the file is a dict with a list of step dicts and string `message` fields. If the JSON root is an array, `steps` is an object, a step is a string, or `message` is nested JSON, it raises `AttributeError` (`.get` / `.strip` on the wrong type) and the whole grader dies before writing `info.json`.

Because of this I have added type checks: non-object JSON and a non-list `steps` return an empty final output, non-dict steps are skipped, and a non-string `message` is skipped. If a later step is a proper agent message, that is still used.

## Why this is needed

Agent traces are not always well-formed. One bad step should not abort grading. Right now the process exits with a traceback and no reward/info files, which is hard to debug in a batch of runs.

## How I tested

I ran `hatch test --include python=3.12 tests/test_trajectory.py` locally on Windows (12 passed). New cases cover JSON array root, `steps` as an object, mixed non-dict steps, and a dict `message`.

## Notes

This PR is only this fix. Other issues are in separate PRs so they can be reviewed independently.

Made with [Cursor](https://cursor.com)