### PR TITLE
Treat malformed judge output as criterion errors, not a crash

### DIFF
--- a/src/gandalf/orchestrator.py
+++ b/src/gandalf/orchestrator.py
@@ -27,7 +27,7 @@ import sys
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
 
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from gandalf.models import (
     BatchJudgeInput,
@@ -325,17 +325,21 @@ def run_judge(
         with open(output_path) as f:
             data = json.load(f)
 
-    except subprocess.TimeoutExpired:
-        save_trace(trace_path, "", "Judge execution timed out.", -1)
-        return fail("Judge execution timed out.")
-    except (json.JSONDecodeError, FileNotFoundError) as e:
-        return fail(f"Failed to read judge output: {e}")
-    else:
+        if not isinstance(data, dict):
+            return fail(f"Failed to read judge output: expected object, got {type(data).__name__}")
+
         if batch:
             verdicts = TypeAdapter(list[Verdict]).validate_python(data["verdicts"])
         else:
             verdicts = [Verdict.model_validate(data["verdict"])]
         usage = LLMUsage.model_validate(data["llm_usage"])
+
+    except subprocess.TimeoutExpired:
+        save_trace(trace_path, "", "Judge execution timed out.", -1)
+        return fail("Judge execution timed out.")
+    except (json.JSONDecodeError, FileNotFoundError, KeyError, TypeError, ValidationError) as e:
+        return fail(f"Failed to read judge output: {e}")
+    else:
         return verdicts, usage
     finally:
         shutil.rmtree(clone_dir, ignore_errors=True)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -490,6 +490,67 @@ class TestEvaluateAllCriteria:
         assert all(v.met is None for v in verdicts)
         assert usage == LLMUsage()
 
+    @patch("gandalf.orchestrator.clone_workspace")
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_missing_verdicts_key_returns_fail_all(
+        self, mock_run: Any, mock_clone: Any, tmp_path: pathlib.Path
+    ) -> None:
+        """Valid JSON missing the verdicts key must not raise KeyError out of run_judge."""
+        mock_clone.return_value = str(tmp_path)
+        mock_run.side_effect = make_run_writing({"llm_usage": {"cost_usd": 0.1}})
+
+        judge_input = make_batch_input(tmp_path, n=2)
+        trace_path = str(tmp_path / "trace.txt")
+
+        verdicts, usage = run_judge(judge_input, sandbox_user="sandbox", trace_path=trace_path)
+
+        assert len(verdicts) == 2
+        assert all(v.met is None for v in verdicts)
+        assert "Failed to read judge output" in verdicts[0].reasoning
+        assert usage == LLMUsage()
+
+    @patch("gandalf.orchestrator.clone_workspace")
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_missing_llm_usage_key_returns_fail_all(
+        self, mock_run: Any, mock_clone: Any, tmp_path: pathlib.Path
+    ) -> None:
+        """Valid JSON missing llm_usage must not raise KeyError out of run_judge."""
+        mock_clone.return_value = str(tmp_path)
+        mock_run.side_effect = make_run_writing(
+            {
+                "verdicts": [
+                    {"index": 0, "met": True, "reasoning": "ok", "evidence": []},
+                ]
+            }
+        )
+
+        judge_input = make_batch_input(tmp_path, n=1)
+        trace_path = str(tmp_path / "trace.txt")
+
+        verdicts, usage = run_judge(judge_input, sandbox_user="sandbox", trace_path=trace_path)
+
+        assert len(verdicts) == 1
+        assert verdicts[0].met is None
+        assert "Failed to read judge output" in verdicts[0].reasoning
+        assert usage == LLMUsage()
+
+    @patch("gandalf.orchestrator.clone_workspace")
+    @patch("gandalf.orchestrator.subprocess.run")
+    def test_non_object_output_returns_fail_all(self, mock_run: Any, mock_clone: Any, tmp_path: pathlib.Path) -> None:
+        """A JSON array in the output file must not crash run_judge."""
+        mock_clone.return_value = str(tmp_path)
+        mock_run.side_effect = make_run_writing([{"met": True, "reasoning": "ok"}])
+
+        judge_input = make_batch_input(tmp_path, n=1)
+        trace_path = str(tmp_path / "trace.txt")
+
+        verdicts, usage = run_judge(judge_input, sandbox_user="sandbox", trace_path=trace_path)
+
+        assert len(verdicts) == 1
+        assert verdicts[0].met is None
+        assert "expected object" in verdicts[0].reasoning
+        assert usage == LLMUsage()
+
 
 @pytest.fixture
 def fake_judge(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:


### PR DESCRIPTION
## Summary

I ran into this when the inner judge exited 0 but wrote JSON that was not the expected object. `run_judge` already turns invalid JSON into error verdicts, but a missing `verdicts` / `verdict` / `llm_usage` key, or a JSON array at the root, raised `KeyError` / `TypeError` / `ValidationError` *after* the subprocess succeeded. That exception left the try/except, so the whole grader died and never wrote `info.json`.

Because of this I moved the shape/key parsing into the same failure path as invalid JSON. Those cases now return error verdicts (`met=None`) for every criterion, same as a timeout or a bad JSON blob.

## Why this is needed

A slightly wrong judge payload should be a failed evaluation, not an uncaught crash. In a batch of runs you otherwise get a traceback and no `info.json`, which is hard to debug.

## How I tested

I ran `hatch test --include python=3.12 tests/test_orchestrator.py::TestEvaluateAllCriteria` locally on Windows (8 passed). New cases cover missing `verdicts`, missing `llm_usage`, and a JSON array root.

## Notes

This PR is only this fix. Other issues are in separate PRs so they can be reviewed independently.

Made with [Cursor](https://cursor.com)