### PR TITLE
Exit with a clear error when the trajectory file is not valid JSON.

### DIFF
--- a/src/gandalf/orchestrator.py
+++ b/src/gandalf/orchestrator.py
@@ -45,8 +45,15 @@ from gandalf.models import (
 
 def load_trajectory_final_output(path: str) -> str:
     """Load an ATIF trajectory file and extract the final agent message."""
-    with open(path) as f:
-        data = json.load(f)
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        print(  # noqa: T201
+            f"ERROR: Invalid JSON in trajectory file: {path}\n  {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     steps = data.get("steps", [])
 

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -30,6 +30,13 @@ class TestLoadTrajectoryFinalOutput:
         with pytest.raises(FileNotFoundError):
             load_trajectory_final_output("/nonexistent/trajectory.json")
 
+    def test_invalid_json_exits(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "bad.json"
+        p.write_text("{not json")
+        with pytest.raises(SystemExit) as exc_info:
+            load_trajectory_final_output(str(p))
+        assert exc_info.value.code == 1
+
     def test_skips_trailing_empty_message(self, tmp_path: pathlib.Path) -> None:
         """When the last agent message has empty content (e.g. reasoning-only
         turn), the function should return the preceding non-empty message."""


### PR DESCRIPTION
Broken trajectory JSON used to dump a JSONDecodeError traceback and skip writing info.json. The grader now prints the file path and parse error and exits 1, same pattern as a missing instructions file.